### PR TITLE
Add section for Mangum to third-party plugins

### DIFF
--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -66,13 +66,14 @@ A library for using any ASGI application with FaaS platforms.
 
 It includes:
 
-* Middleware classes for **AWS Lambda & API Gateway** and **Azure Functions**.
+* Adapter classes for **AWS Lambda & API Gateway** and **Azure Functions**.
 * CLI tools (experimental) for generating, packaging, and validating AWS deployment configurations.
 
 ```Python
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
-from mangum.platforms.aws.middleware import AWSLambdaMiddleware
+from mangum.platforms.aws.adapter import AWSLambdaAdapter
+# from mangum.platforms.azure.adapter import AzureFunctionAdapter
 
 
 app = Starlette()
@@ -83,7 +84,8 @@ def homepage(request):
     return PlainTextResponse("Hello, world!")
 
 
-handler = AWSLambdaMiddleware(app)  # optionally set debug=True
+handler = AWSLambdaAdapter(app)  # optionally set debug=True
+# handler = AzureFunctionAdapter(app)
 ```
 
 

--- a/docs/third-party-packages.md
+++ b/docs/third-party-packages.md
@@ -24,9 +24,7 @@ That library aims to bring a layer on top of Starlette framework to provide usef
 * **Components** as the base of the plugin ecosystem, allowing you to create custom or use those already defined in your endpoints, injected as parameters.
 * **Starlette ASGI** objects like `Request`, `Response`, `Session` and so on are defined as components and ready to be injected in your endpoints.
 
-
 ### webargs-starlette
-
 
 Link: <a href="https://github.com/sloria/webargs-starlette" target="_blank">https://github.com/sloria/webargs-starlette</a>
 
@@ -58,6 +56,34 @@ if __name__ == "__main__":
 # {"Hello": "World"}
 # curl 'http://localhost:5000/?name=Ada'
 # {"Hello": "Ada"}
+```
+
+### Mangum
+
+Link: <a href="https://github.com/erm/mangum" target="_blank">https://github.com/erm/mangum</a>
+
+A library for using any ASGI application with FaaS platforms.
+
+It includes:
+
+* Middleware classes for **AWS Lambda & API Gateway** and **Azure Functions**.
+* CLI tools (experimental) for generating, packaging, and validating AWS deployment configurations.
+
+```Python
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from mangum.platforms.aws.middleware import AWSLambdaMiddleware
+
+
+app = Starlette()
+
+
+@app.route("/")
+def homepage(request):
+    return PlainTextResponse("Hello, world!")
+
+
+handler = AWSLambdaMiddleware(app)  # optionally set debug=True
 ```
 
 


### PR DESCRIPTION
Adds a section for https://github.com/erm/mangum under the Plugins heading.
