### PR TITLE
Remove coverage config

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ export PYTHON_VERSION=`python -c "$VERSION_SCRIPT"`
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov-config tests/.ignore_lifespan -W ignore::DeprecationWarning --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
+PYTHONPATH=. ${PREFIX}pytest --ignore venv -W ignore::DeprecationWarning --cov=starlette --cov=tests --cov-fail-under=100 --cov-report=term-missing ${@}
 ${PREFIX}mypy starlette --ignore-missing-imports --disallow-untyped-defs
 ${PREFIX}autoflake --recursive starlette tests setup.py
 ${PREFIX}black starlette tests setup.py --check

--- a/tests/.ignore_lifespan
+++ b/tests/.ignore_lifespan
@@ -1,3 +1,0 @@
-[coverage:run]
-omit =
-  starlette/middleware/lifespan.py


### PR DESCRIPTION
The deprecated middleware was removed in 4d5708e.

Ref: https://github.com/encode/starlette/pull/423#issuecomment-470266857