### PR TITLE
Fix Staticfiles `404.html` in HTML mode

### DIFF
--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -229,7 +229,7 @@ def test_staticfiles_304_with_last_modified_compare_last_req(
     assert response.content == b"<file content>"
 
 
-def test_staticfiles_html(tmpdir, test_client_factory):
+def test_staticfiles_html_normal(tmpdir, test_client_factory):
     path = os.path.join(tmpdir, "404.html")
     with open(path, "w") as file:
         file.write("<h1>Custom not found page</h1>")
@@ -256,6 +256,31 @@ def test_staticfiles_html(tmpdir, test_client_factory):
     assert response.url == "http://testserver/dir/index.html"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
+
+    response = client.get("/missing")
+    assert response.status_code == 404
+    assert response.text == "<h1>Custom not found page</h1>"
+
+
+def test_staticfiles_html_without_index(tmpdir, test_client_factory):
+    path = os.path.join(tmpdir, "404.html")
+    with open(path, "w") as file:
+        file.write("<h1>Custom not found page</h1>")
+    path = os.path.join(tmpdir, "dir")
+    os.mkdir(path)
+
+    app = StaticFiles(directory=tmpdir, html=True)
+    client = test_client_factory(app)
+
+    response = client.get("/dir/")
+    assert response.url == "http://testserver/dir/"
+    assert response.status_code == 404
+    assert response.text == "<h1>Custom not found page</h1>"
+
+    response = client.get("/dir")
+    assert response.url == "http://testserver/dir/"
+    assert response.status_code == 404
+    assert response.text == "<h1>Custom not found page</h1>"
 
     response = client.get("/missing")
     assert response.status_code == 404

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -287,6 +287,31 @@ def test_staticfiles_html_without_index(tmpdir, test_client_factory):
     assert response.text == "<h1>Custom not found page</h1>"
 
 
+def test_staticfiles_html_without_404(tmpdir, test_client_factory):
+    path = os.path.join(tmpdir, "dir")
+    os.mkdir(path)
+    path = os.path.join(path, "index.html")
+    with open(path, "w") as file:
+        file.write("<h1>Hello</h1>")
+
+    app = StaticFiles(directory=tmpdir, html=True)
+    client = test_client_factory(app)
+
+    response = client.get("/dir/")
+    assert response.url == "http://testserver/dir/"
+    assert response.status_code == 200
+    assert response.text == "<h1>Hello</h1>"
+
+    response = client.get("/dir")
+    assert response.url == "http://testserver/dir/"
+    assert response.status_code == 200
+    assert response.text == "<h1>Hello</h1>"
+
+    response = client.get("/missing")
+    assert response.status_code == 404
+    assert response.text == "Not Found"
+
+
 def test_staticfiles_cache_invalidation_for_deleted_file_html_mode(
     tmpdir, test_client_factory
 ):

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -303,9 +303,8 @@ def test_staticfiles_html_without_404(tmpdir, test_client_factory):
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
 
-    response = client.get("/missing")
-    assert response.status_code == 404
-    assert response.text == "Not Found"
+    with pytest.raises(HTTPException) as exc_info:
+        response = client.get("/missing")
 
 
 def test_staticfiles_html_only_files(tmpdir, test_client_factory):
@@ -316,17 +315,12 @@ def test_staticfiles_html_only_files(tmpdir, test_client_factory):
     app = StaticFiles(directory=tmpdir, html=True)
     client = test_client_factory(app)
 
-    response = client.get("/dir")
-    assert response.status_code == 404
-    assert response.text == "Not Found"
+    with pytest.raises(HTTPException) as exc_info:
+        response = client.get("/")
 
     response = client.get("/hello.html")
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
-
-    response = client.get("/missing")
-    assert response.status_code == 404
-    assert response.text == "Not Found"
 
 
 def test_staticfiles_cache_invalidation_for_deleted_file_html_mode(

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -312,6 +312,28 @@ def test_staticfiles_html_without_404(tmpdir, test_client_factory):
     assert response.text == "Not Found"
 
 
+def test_staticfiles_html_only_files(tmpdir, test_client_factory):
+    path = os.path.join(tmpdir, "hello.html")
+    with open(path, "w") as file:
+        file.write("<h1>Hello</h1>")
+
+    app = StaticFiles(directory=tmpdir, html=True)
+    client = test_client_factory(app)
+
+    response = client.get("/dir")
+    assert response.url == "http://testserver/"
+    assert response.status_code == 404
+    assert response.text == "Not Found"
+
+    response = client.get("/hello.html")
+    assert response.status_code == 200
+    assert response.text == "<h1>Hello</h1>"
+
+    response = client.get("/missing")
+    assert response.status_code == 404
+    assert response.text == "Not Found"
+
+
 def test_staticfiles_cache_invalidation_for_deleted_file_html_mode(
     tmpdir, test_client_factory
 ):

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -273,10 +273,12 @@ def test_staticfiles_html_without_index(tmpdir, test_client_factory):
     client = test_client_factory(app)
 
     response = client.get("/dir/")
+    assert response.url == "http://testserver/dir/"
     assert response.status_code == 404
     assert response.text == "<h1>Custom not found page</h1>"
 
     response = client.get("/dir")
+    assert response.url == "http://testserver/dir/"
     assert response.status_code == 404
     assert response.text == "<h1>Custom not found page</h1>"
 
@@ -296,10 +298,12 @@ def test_staticfiles_html_without_404(tmpdir, test_client_factory):
     client = test_client_factory(app)
 
     response = client.get("/dir/")
+    assert response.url == "http://testserver/dir/"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
 
     response = client.get("/dir")
+    assert response.url == "http://testserver/dir/"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -273,12 +273,10 @@ def test_staticfiles_html_without_index(tmpdir, test_client_factory):
     client = test_client_factory(app)
 
     response = client.get("/dir/")
-    assert response.url == "http://testserver/dir/"
     assert response.status_code == 404
     assert response.text == "<h1>Custom not found page</h1>"
 
     response = client.get("/dir")
-    assert response.url == "http://testserver/dir/"
     assert response.status_code == 404
     assert response.text == "<h1>Custom not found page</h1>"
 
@@ -298,12 +296,10 @@ def test_staticfiles_html_without_404(tmpdir, test_client_factory):
     client = test_client_factory(app)
 
     response = client.get("/dir/")
-    assert response.url == "http://testserver/dir/"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
 
     response = client.get("/dir")
-    assert response.url == "http://testserver/dir/"
     assert response.status_code == 200
     assert response.text == "<h1>Hello</h1>"
 
@@ -321,7 +317,6 @@ def test_staticfiles_html_only_files(tmpdir, test_client_factory):
     client = test_client_factory(app)
 
     response = client.get("/dir")
-    assert response.url == "http://testserver/"
     assert response.status_code == 404
     assert response.text == "Not Found"
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -278,7 +278,7 @@ def test_staticfiles_html_without_index(tmpdir, test_client_factory):
     assert response.text == "<h1>Custom not found page</h1>"
 
     response = client.get("/dir")
-    assert response.url == "http://testserver/dir/"
+    assert response.url == "http://testserver/dir"
     assert response.status_code == 404
     assert response.text == "<h1>Custom not found page</h1>"
 
@@ -309,6 +309,7 @@ def test_staticfiles_html_without_404(tmpdir, test_client_factory):
 
     with pytest.raises(HTTPException) as exc_info:
         response = client.get("/missing")
+    assert exc_info.value.status_code == 404
 
 
 def test_staticfiles_html_only_files(tmpdir, test_client_factory):
@@ -321,6 +322,7 @@ def test_staticfiles_html_only_files(tmpdir, test_client_factory):
 
     with pytest.raises(HTTPException) as exc_info:
         response = client.get("/")
+    assert exc_info.value.status_code == 404
 
     response = client.get("/hello.html")
     assert response.status_code == 200


### PR DESCRIPTION
In StaticFiles html-mode, when `404.html` and `index.html` files were missing, a FileNotFoundError exception was rised. As I understand it, a non-existent file was checked in the `os.stat` function

However, this is not the whole problem. Even if `404.html` exists, it might not be returned, because after checking for the existence of `index.html`, a basic 404 exception is returned, rather than returning a `404.html` file with the correct status code

Therefore, I moved the check for the existence of a `404.html` to the end, when index cannot be found. I also considered it correct to move the file absence exception to the `lookup_path` and, in case of absence, return an empty string and None, so as not to process Exception several times.

_Sorry for my bad english_