### PR TITLE
Pin importlib-metadata to 4.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ black==22.8.0
 coverage==6.4.2
 databases[sqlite]==0.6.1
 flake8==3.9.2
+importlib-metadata==4.13.0
 isort==5.10.1
 mypy==0.971
 typing_extensions==4.3.0


### PR DESCRIPTION
Same solution as https://github.com/encode/httpcore/pull/590.