### PR TITLE
added safety for missing keys in WebSocketDisconnect raise

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -127,7 +127,14 @@ class WebSocket(HTTPConnection):
 
     def _raise_on_disconnect(self, message: Message) -> None:
         if message["type"] == "websocket.disconnect":
-            raise WebSocketDisconnect(message["code"], message.get("reason"))
+            params = {}
+            if "code" in message:
+                params["code"] = message["code"]
+            if "reason" in message:
+                params["reason"] = message["reason"]
+            
+            raise WebSocketDisconnect(**params)
+
 
     async def receive_text(self) -> str:
         if self.application_state != WebSocketState.CONNECTED:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Saw issues in an app using FastAPI like:

```
  File "/Users/matt/code/agentzero/venv/lib/python3.10/site-packages/starlette/websockets.py", line 105, in _raise_on_disconnect
    raise WebSocketDisconnect(message["code"])
KeyError: 'code'
```

Discovered that while I was catching starlette.WebSocketDisconnect, it lacked a 'code' field which was throwing a KeyError which also had to be caught.

eg:

```
        try:
            data = await websocket.receive_text()
            data_json = json.loads(data)  # Convert the received text to a JSON object
            user_input = data_json.get('user_input')  # Extract the user_input part
        except json.JSONDecodeError as e:
            logging.error(f"Error decoding JSON from WebSocket: {e}")
            continue  # Skip to the next iteration on error
        except WebSocketDisconnect as e:
            logging.info(f"WebSocket disconnected: {e}. Client likely closed the connection.")
            break
        except Exception as e:
            if str(e) == 'code':
                logging.info(f"WebSocket disconnected: starlette error code (code). Client likely closed the connection.")
                break
```

This should make the params safe.

Very likely the issue here: https://github.com/encode/starlette/discussions/2434

# Checklist

- [ x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ n/a ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ n/a ] I've updated the documentation accordingly.
