### PR TITLE
Make UploadFile check for future rollover

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -437,8 +437,8 @@ class UploadFile:
         # check for SpooledTemporaryFile._rolled
         rolled_to_disk = getattr(self.file, "_rolled", True)
         return not rolled_to_disk
-    
-    def _will_roll(self, size_to_add: int)->bool:
+
+    def _will_roll(self, size_to_add: int) -> bool:
         # If we're not in_memory then we will always roll
         if not self._in_memory:
             return True
@@ -447,8 +447,8 @@ class UploadFile:
         max_size = getattr(self.file, "_max_size", None)
         if max_size is None:
             return False
-        
-        return ((self.file.tell()+size_to_add)>self.file._max_size)
+
+        return bool((self.file.tell() + size_to_add) > max_size)
 
     async def write(self, data: bytes) -> None:
         new_data_len = len(data)
@@ -458,7 +458,7 @@ class UploadFile:
         if self._will_roll(new_data_len):
             await run_in_threadpool(self.file.write, data)
         else:
-            self.file.write(data)            
+            self.file.write(data)
 
     async def read(self, size: int = -1) -> bytes:
         if self._in_memory:

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -428,9 +428,8 @@ class UploadFile:
         self.size = size
         self.headers = headers or Headers()
 
-        # Capture max size from SpooledTemporaryFile if one is provided. This
-        # slightly speeds up future checks. Note 0 means unlimited mirroring
-        # SpooledTemporaryFile's __init__
+        # Capture max size from SpooledTemporaryFile if one is provided. This slightly speeds up future checks.
+        # Note 0 means unlimited mirroring SpooledTemporaryFile's __init__
         self._max_mem_size = getattr(self.file, "_max_size", 0)
 
     @property

--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -445,10 +445,8 @@ class UploadFile:
 
         # Check for SpooledTemporaryFile._max_size
         max_size = getattr(self.file, "_max_size", None)
-        if max_size is None:
-            return False
-
-        return bool((self.file.tell() + size_to_add) > max_size)
+        future_size = self.file.tell() + size_to_add
+        return bool(future_size > max_size) if max_size is not None else False
 
     async def write(self, data: bytes) -> None:
         new_data_len = len(data)

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -4,7 +4,10 @@ import os
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from io import BytesIO
 from pathlib import Path
+from tempfile import SpooledTemporaryFile
+import threading
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -102,6 +105,20 @@ async def app_read_body(scope: Scope, receive: Receive, send: Send) -> None:
         output[key] = value
     await request.close()
     response = JSONResponse(output)
+    await response(scope, receive, send)
+
+
+async def app_monitor_thread(scope: Scope, receive: Receive, send: Send) -> None:
+    """Helper app to monitor what thread the app was called on. This can later
+    be used to validate thread/event loop operations"""
+    request = Request(scope, receive)
+
+    # Make sure we parse the form
+    await request.form()
+    await request.close()
+
+    # Send back the current thread id
+    response = JSONResponse({"thread_ident": threading.current_thread().ident})
     await response(scope, receive, send)
 
 
@@ -304,14 +321,37 @@ def test_multipart_request_mixed_files_and_data(tmpdir: Path, test_client_factor
     }
 
 
+class ThreadTrackingSpooledTemporaryFile(SpooledTemporaryFile):
+    """Helper class to track which threads performed the rollover operation. This is
+    not threadsafe/multi-test safe"""
+
+    rollover_threads: set[int] = set()
+
+    def rollover(self):
+        ThreadTrackingSpooledTemporaryFile.rollover_threads.add(threading.current_thread().ident)
+        return super().rollover()
+
+
 def test_multipart_request_large_file(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
     data = BytesIO(b" " * MultiPartParser.spool_max_size * 2)
-    client = test_client_factory(app)
-    response = client.post(
-        "/",
-        files=[("test_large", data)],
-    )
-    assert response.status_code == 200
+
+    # Mock the formparser to use our monitoring class
+    with mock.patch("starlette.formparsers.SpooledTemporaryFile", ThreadTrackingSpooledTemporaryFile):
+        client = test_client_factory(app_monitor_thread)
+        response = client.post(
+            "/",
+            files=[("test_large", data)],
+        )
+        assert response.status_code == 200
+
+        # Parse the event thread id from the API response and ensure we have one
+        app_thread_ident = response.json().get("thread_ident")
+        assert app_thread_ident
+
+        # Ensure the app thread was not the same as the rollover one and that a rollover thread
+        # exists
+        assert app_thread_ident not in ThreadTrackingSpooledTemporaryFile.rollover_threads
+        assert len(ThreadTrackingSpooledTemporaryFile.rollover_threads) > 0
 
 
 def test_multipart_request_with_charset_for_filename(tmpdir: Path, test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR ensures that during multi-part form parsing any slow disk IO happens in a background. This specifically fixes a case where a file would rollover during a `write()` call as talked about in [this discussion.](https://github.com/encode/starlette/discussions/2927#discussioncomment-13721403)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
