### PR TITLE
Option to allow private network access in CORS middleware.

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -75,6 +75,7 @@ The following arguments are supported:
 * `allow_origin_regex` - A regex string to match against origins that should be permitted to make cross-origin requests. eg. `'https://.*\.example\.org'`.
 * `allow_methods` - A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `['GET']`. You can use `['*']` to allow all standard methods.
 * `allow_headers` - A list of HTTP request headers that should be supported for cross-origin requests. Defaults to `[]`. You can use `['*']` to allow all headers. The `Accept`, `Accept-Language`, `Content-Language` and `Content-Type` headers are always allowed for CORS requests.
+* `allow_private_network` - Set to `True` to allow private network access for cross-origin requests. Defaults to `False`.
 * `allow_credentials` - Indicate that cookies should be supported for cross-origin requests. Defaults to `False`. Also, `allow_origins`, `allow_methods` and `allow_headers` cannot be set to `['*']` for credentials to be allowed, all of them must be explicitly specified.
 * `expose_headers` - Indicate any response headers that should be made accessible to the browser. Defaults to `[]`.
 * `max_age` - Sets a maximum time in seconds for browsers to cache CORS responses. Defaults to `600`.

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -20,6 +20,7 @@ class CORSMiddleware:
         allow_methods: Sequence[str] = ("GET",),
         allow_headers: Sequence[str] = (),
         allow_credentials: bool = False,
+        allow_private_network: bool = False,
         allow_origin_regex: str | None = None,
         expose_headers: Sequence[str] = (),
         max_age: int = 600,
@@ -40,6 +41,8 @@ class CORSMiddleware:
             simple_headers["Access-Control-Allow-Origin"] = "*"
         if allow_credentials:
             simple_headers["Access-Control-Allow-Credentials"] = "true"
+        if allow_private_network:
+            simple_headers["Access-Control-Allow-Private-Network"] = "true"
         if expose_headers:
             simple_headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
 
@@ -52,6 +55,7 @@ class CORSMiddleware:
         preflight_headers.update(
             {
                 "Access-Control-Allow-Methods": ", ".join(allow_methods),
+                "Access-Control-Allow-Private-Network": "true" if allow_private_network else "false",
                 "Access-Control-Max-Age": str(max_age),
             }
         )
@@ -68,6 +72,7 @@ class CORSMiddleware:
         self.allow_all_origins = allow_all_origins
         self.allow_all_headers = allow_all_headers
         self.preflight_explicit_allow_origin = preflight_explicit_allow_origin
+        self.allow_private_network = allow_private_network
         self.allow_origin_regex = compiled_allow_origin_regex
         self.simple_headers = simple_headers
         self.preflight_headers = preflight_headers


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

The versions of Chrome browser after 130 require an additional header "Access-Control-Allow-Private-Network": "true" in PREFLIGHT interaction if you are trying to access f.i. a https://localhost resources, where uvicorn / starlette application is running. They promised to start blocking these requests altogether, but didn't, it's just a warning, but a very annoying one.
This is important for the current generation of AI applications if a local server with a Starlette application (not the MCP with FastApi) is used for interactions with a web-based AI application.

<!-- Write a small summary about what is happening here. -->

The allow_private_network parameter has been added to cors.py and the doc.

# Checklist

- [ *] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ *] I've updated the documentation accordingly.
