### PR TITLE
Use `Literal` type for `WebSocketEndpoint` encoding values

### DIFF
--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from starlette import status
 from starlette._utils import is_async_callable
@@ -52,7 +52,7 @@ class HTTPEndpoint:
 
 
 class WebSocketEndpoint:
-    encoding: str | None = None  # May be "text", "bytes", or "json".
+    encoding: Literal["text", "bytes", "json"] | None = None
 
     def __init__(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] == "websocket"


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Use [Literal](https://docs.python.org/3/library/typing.html#typing.Literal) type to better type the accepted values for encoding in WebSocketEndpoint

The [documentation](https://www.starlette.dev/endpoints/) already states that it only accepts 'text', 'bytes' or 'json' so this only enforces it at typing level

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
