### PR TITLE
docs: fix legibility issues on sponsorship page

### DIFF
--- a/docs/sponsorship.md
+++ b/docs/sponsorship.md
@@ -59,8 +59,8 @@ We currently manage sponsorships *exclusively* through **GitHub Sponsors**. This
 
 ## Sponsorship Tiers 🎁
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
-    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: #fff; display: flex; flex-direction: column;">
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0; color: #fff">
+    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: linear-gradient(135deg, #6e5494, #24292e); display: flex; flex-direction: column;">
         <h3 style="color: #cd7f32;">🥉 Bronze Sponsor</h3>
         <div style="font-size: 1.5em; margin: 1rem 0;">$100<span style="font-size: 0.6em;">/month</span></div>
         <ul style="list-style: none; padding: 0; margin-bottom: 1rem; min-height: 90px;">
@@ -74,7 +74,7 @@ We currently manage sponsorships *exclusively* through **GitHub Sponsors**. This
             </a>
         </div>
     </div>
-    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: #fff; display: flex; flex-direction: column;">
+    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: linear-gradient(135deg, #6e5494, #24292e); display: flex; flex-direction: column;">
         <h3 style="color: #c0c0c0;">🥈 Silver Sponsor</h3>
         <div style="font-size: 1.5em; margin: 1rem 0;">$250<span style="font-size: 0.6em;">/month</span></div>
         <ul style="list-style: none; padding: 0; margin-bottom: 1rem; min-height: 90px;">
@@ -88,7 +88,7 @@ We currently manage sponsorships *exclusively* through **GitHub Sponsors**. This
             </a>
         </div>
     </div>
-    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: #fff; position: relative; overflow: hidden; display: flex; flex-direction: column;">
+    <div style="padding: 1.5rem; border: 1px solid #e1e4e8; border-radius: 6px; background: linear-gradient(135deg, #6e5494, #24292e); position: relative; overflow: hidden; display: flex; flex-direction: column;">
         <div style="position: absolute; top: 10px; right: -25px; background: #238636; color: white; padding: 5px 30px; transform: rotate(45deg);">
             Popular
         </div>
@@ -148,7 +148,7 @@ We currently manage sponsorships *exclusively* through **GitHub Sponsors**. This
 
 ## Alternative Sponsorship Platforms
 
-<div style="background: #f6f8fa; padding: 1.5rem; border-radius: 8px; margin: 2rem 0;">
+<div style="background: linear-gradient(135deg, var(--md-default-fg-color--lighter), var(--md-default-fg-color--lightest)); padding: 1.5rem; border-radius: 8px; margin: 2rem 0;">
     <h3>📢 We Want Your Input!</h3>
     <p>We are currently evaluating whether to expand our sponsorship options beyond GitHub Sponsors. If your company would be interested in sponsoring Starlette and Uvicorn but prefers to use a different platform (e.g., Open Collective, direct invoicing), please let us know!</p>
     <p>Your feedback is invaluable in helping us make sponsorship as accessible as possible. Share your thoughts by:</p>


### PR DESCRIPTION
The material mkdocs theme supports a light and dark theme option. When set to dark, the font changes to a light (white) color, causing it to be unreadable with the current light background.

This fix adjust the sponsorship tier cards to have the same styling as the card "Become a Sponsor Today" card above. The "Alternative Sponsorship Platform" section also suffered from this issue, so it is now set to a gray that adapts based on light or dark theme.

Closes: #3006

--

Screenshots of the applied fix on a local instance using `./scripts/docs`: 

<img width="942" height="472" alt="light-theme-alternative-sponsoring" src="https://github.com/user-attachments/assets/ae01abc3-ed62-41b7-b208-f95b32dcfdaa" />
<img width="955" height="468" alt="dark-theme-alternative-sponsoring" src="https://github.com/user-attachments/assets/bc30d483-75ce-4cc3-9f96-c44fe87bdbb6" />
<img width="959" height="565" alt="light-theme-sponsorship-tiers" src="https://github.com/user-attachments/assets/711f6261-5e43-4f8c-8918-353b494d17e1" />
<img width="956" height="567" alt="dark-theme-sponsorship-tiers" src="https://github.com/user-attachments/assets/de73b6cf-06a4-4574-8c30-eed3eaf4494a" />


<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
