### PR TITLE
[FileResponse] allow pre-opening of file

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -14,7 +14,7 @@ from email.utils import format_datetime, formatdate
 from functools import partial
 from mimetypes import guess_type
 from secrets import token_hex
-from typing import Any, Callable, Literal, Union
+from typing import IO, Any, Callable, Literal, Union
 from urllib.parse import quote
 
 import anyio
@@ -308,6 +308,7 @@ class FileResponse(Response):
         stat_result: os.stat_result | None = None,
         method: str | None = None,
         content_disposition_type: str = "attachment",
+        file: IO[bytes] | None = None,
     ) -> None:
         self.path = path
         self.status_code = status_code
@@ -333,6 +334,8 @@ class FileResponse(Response):
         self.stat_result = stat_result
         if stat_result is not None:
             self.set_stat_headers(stat_result)
+
+        self.file = file
 
     def set_stat_headers(self, stat_result: os.stat_result) -> None:
         content_length = str(stat_result.st_size)
@@ -385,14 +388,20 @@ class FileResponse(Response):
         if self.background is not None:
             await self.background()
 
+    async def _open_file(self) -> anyio.AsyncFile[bytes]:
+        if self.file is not None:
+            return anyio.wrap_file(self.file)
+        else:
+            return await anyio.open_file(self.path, mode="rb")
+
     async def _handle_simple(self, send: Send, send_header_only: bool, send_pathsend: bool) -> None:
         await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
-        elif send_pathsend:
+        elif send_pathsend and self.file is None:
             await send({"type": "http.response.pathsend", "path": str(self.path)})
         else:
-            async with await anyio.open_file(self.path, mode="rb") as file:
+            async with await self._open_file() as file:
                 more_body = True
                 while more_body:
                     chunk = await file.read(self.chunk_size)
@@ -408,7 +417,7 @@ class FileResponse(Response):
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
-            async with await anyio.open_file(self.path, mode="rb") as file:
+            async with await self._open_file() as file:
                 await file.seek(start)
                 more_body = True
                 while more_body:
@@ -435,7 +444,7 @@ class FileResponse(Response):
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
         else:
-            async with await anyio.open_file(self.path, mode="rb") as file:
+            async with await self._open_file() as file:
                 for start, end in ranges:
                     await send({"type": "http.response.body", "body": header_generator(start, end), "more_body": True})
                     await file.seek(start)

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -349,7 +349,7 @@ class FileResponse(Response):
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         send_header_only: bool = scope["method"].upper() == "HEAD"
-        send_pathsend: bool = "http.response.pathsend" in scope.get("extensions", {})
+        send_pathsend: bool = self.file is None and "http.response.pathsend" in scope.get("extensions", {})
 
         if self.stat_result is None:
             try:
@@ -398,7 +398,7 @@ class FileResponse(Response):
         await send({"type": "http.response.start", "status": self.status_code, "headers": self.raw_headers})
         if send_header_only:
             await send({"type": "http.response.body", "body": b"", "more_body": False})
-        elif send_pathsend and self.file is None:
+        elif send_pathsend:
             await send({"type": "http.response.pathsend", "path": str(self.path)})
         else:
             async with await self._open_file() as file:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Hello! I am using Starlette (under FastAPI) to serve some **untrusted directories** from disk, and as such I have intentional file opening logic that ensures files are not served from outside the untrusted directory. It's similar to the [common path check in `StaticFiles`](https://github.com/Kludex/starlette/blob/3912d6313730cc6004dfb4436e37dbc1a81db7c8/starlette/staticfiles.py#L157-L162), but checking the path _then_ opening the file is **at risk of [TOCTOU attack](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)** if a symlink is injected into the path between validation and opening (e.g. either `pathsend` or the file open within `FileResponse`). It's a tight squeeze, but definitely possible when the filesystem is writeable, especially by untrusted entities (aka users 😁).

As such, I currently have my own internal adapted version of `FileResponse` that accepts an open `IO[bytes]` which was securely opened without any symlink following.

I just wanted to open this draft to see if you would be amenable to a change like this. (happy to add tests if we can arrive at an acceptable approach through discussion!)

Alternative I considered were:
- `path` gains a third `IO[bytes]` type option -- this muddles the implementation IMO
- `opener: Callable[[str | os.PathLike[str]], Awaitable[anyio.AsyncFile]]` -- more confusing, muddles exception handling IMO

I am fine to keep rolling with my own internal version, but wondered if this might be generally useful to others. It could also be used in combination with changes to `StaticFiles` to close that TOCTOU symlink gap (though since `StaticFiles` is read-only, may not be useful).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
