### PR TITLE
specify typing_extensions in the dev dependency group since it's needed by tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "types-PyYAML==6.0.12.20250516",
     "pytest==8.4.1",
     "trio==0.30.0",
+    "typing_extensions>=4.10.0",
     # Check dist
     "twine==6.1.0"
 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
The typing_extensions module is imported within the tests/test_config.py file.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
