### PR TITLE
Fix: Raise WebSocketDisconnect instead of RuntimeError on closed conn…

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -54,7 +54,7 @@ class WebSocket(HTTPConnection):
                 self.client_state = WebSocketState.DISCONNECTED
             return message
         else:
-            raise RuntimeError('Cannot call "receive" once a disconnect message has been received.')
+            raise WebSocketDisconnect(code=1006)
 
     async def send(self, message: Message) -> None:
         """
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1006)
 
     async def accept(
         self,

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -54,7 +54,7 @@ class WebSocket(HTTPConnection):
                 self.client_state = WebSocketState.DISCONNECTED
             return message
         else:
-            raise WebSocketDisconnect(code=1006)
+            raise WebSocketDisconnect(code=1006, reason='Cannot call "receive" once a disconnect message has been received.')
 
     async def send(self, message: Message) -> None:
         """
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise WebSocketDisconnect(code=1006)
+            raise WebSocketDisconnect(code=1006, reason='Cannot call "send" once a close message has been sent.')
 
     async def accept(
         self,

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -54,7 +54,9 @@ class WebSocket(HTTPConnection):
                 self.client_state = WebSocketState.DISCONNECTED
             return message
         else:
-            raise WebSocketDisconnect(code=1006, reason='Cannot call "receive" once a disconnect message has been received.')
+            raise WebSocketDisconnect(
+                code=1006, reason='Cannot call "receive" once a disconnect message has been received.'
+            )
 
     async def send(self, message: Message) -> None:
         """

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -449,9 +449,10 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/"):
             pass  # pragma: no cover
+    assert exc.value.code == 1006
 
 
 def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:
@@ -463,9 +464,10 @@ def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:
         message = await websocket.receive()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect) as exc:
         with client.websocket_connect("/") as websocket:
             websocket.close()
+    assert exc.value.code == 1006
 
 
 def test_websocket_scope_interface() -> None:


### PR DESCRIPTION
# Summary

Replaces the generic `RuntimeError` with [WebSocketDisconnect](cci:2://file:///c:/Users/manas/Downloads/createpr/starlette/starlette/websockets.py:19:0-22:34) (code 1006) when attempting to [send](cci:1://file:///c:/Users/manas/Downloads/createpr/starlette/starlette/websockets.py:58:4-97:48) or [receive](cci:1://file:///c:/Users/manas/Downloads/createpr/starlette/starlette/websockets.py:34:4-56:48) messages on a WebSocket connection that has already been closed.

This improves error handling by allowing applications to catch a specific exception type instead of relying on string matching for `RuntimeError`.

Fixes #2767.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (No doc changes needed for this internal fix, but tests are updated)