### PR TITLE
Pass 500/Exception handlers to both error middlewares

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -99,6 +99,9 @@ exception_handlers = {
 }
 ```
 
+These handlers are passed to both `ServerErrorMiddleware` and `ExceptionMiddleware`, meaning they
+handle unhandled exceptions (e.g., `RuntimeError`) as well as `HTTPException(status_code=500)`.
+
 It's important to notice that in case a [`BackgroundTask`](background.md) raises an exception,
 it will be handled by the `handle_error` function, but at that point, the response was already sent. In other words,
 the response created by `handle_error` will be discarded. In case the error happens before the response was sent, then

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -79,8 +79,7 @@ class Starlette:
         for key, value in self.exception_handlers.items():
             if key in (500, Exception):
                 error_handler = value
-            else:
-                exception_handlers[key] = value
+            exception_handlers[key] = value
 
         middleware = (
             [Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug)]


### PR DESCRIPTION
# Summary

This PR fixes the long-standing issue where custom `500` and `Exception` handlers are excluded from `ExceptionMiddleware`, causing them to bypass the user middleware stack (including `CORSMiddleware`).

## Problem

Currently in `build_middleware_stack()`, handlers for `500` and `Exception` are special-cased to **only** pass to `ServerErrorMiddleware` and are **excluded** from `ExceptionMiddleware`:

```python
for key, value in self.exception_handlers.items():
    if key in (500, Exception):
        error_handler = value
    else:
        exception_handlers[key] = value  # 500/Exception never added here
```

This causes:
- **CORS headers missing** on 500 responses (browsers can't read error details)
- **Logging/monitoring middleware** cannot track 500 errors  
- **Correlation ID middleware** headers stripped from error responses
- **Inconsistent behavior**: 404 errors pass through middleware, 500 errors don't

## Solution

Remove the `else` clause so `500`/`Exception` handlers are passed to **both** middlewares:

```python
for key, value in self.exception_handlers.items():
    if key in (500, Exception):
        error_handler = value
    exception_handlers[key] = value  # Now always added
```

This allows:
1. `ExceptionMiddleware` to handle the exception first (inside user middleware stack)
2. `ServerErrorMiddleware` to act as a fallback for truly unhandled exceptions

## Related Issues

This addresses the root cause of many long-standing issues:

**Starlette:**
- Fixes #1175 - Custom 500/Exception handlers don't run through middleware
- Fixes #1116 - CORS headers missing on errors

**FastAPI (downstream impact):**
- Resolves fastapi/fastapi#775 / Discussion #7847
- Resolves fastapi/fastapi#4025 / Discussion #8647
- Resolves fastapi/fastapi#2094 / Discussion #7315
- Resolves fastapi/fastapi#457
- Resolves fastapi/fastapi#5263
- Resolves fastapi/fastapi#4071

## Backward Compatibility

- **Debug mode**: `ServerErrorMiddleware` still provides debug tracebacks as fallback
- **No handler registered**: Behavior unchanged (ServerErrorMiddleware handles it)
- **Handler registered**: Now runs through middleware stack first, with ServerErrorMiddleware as safety net

