### PR TITLE
chore: Increase warning stacklevel

### DIFF
--- a/starlette/middleware/wsgi.py
+++ b/starlette/middleware/wsgi.py
@@ -16,6 +16,7 @@ warnings.warn(
     "starlette.middleware.wsgi is deprecated and will be removed in a future release. "
     "Please refer to https://github.com/abersheeran/a2wsgi as a replacement.",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 


### PR DESCRIPTION
This PR just improves warning making it refer to the code that is importing `starlette.middleware.wsgi` and not to this file itself.
