### PR TITLE
Remove processed background tasks from queue

### DIFF
--- a/starlette/background.py
+++ b/starlette/background.py
@@ -32,5 +32,6 @@ class BackgroundTasks(BackgroundTask):
         self.tasks.append(task)
 
     async def __call__(self) -> None:
-        for task in self.tasks:
+        while self.tasks:
+            task = self.tasks.pop(0)
             await task()


### PR DESCRIPTION
## Summary
- Modify `BackgroundTasks.__call__` to remove tasks from the list after execution
- Add test to verify tasks are removed after processing

This enables users to monitor the queue length for implementing features like graceful shutdowns. Previously, all tasks remained in the list even after execution, making it impossible to determine how many tasks were still pending.

## Use Case
```python
@app.get("/get_queue_length/")
async def read_task():
    return {"task_length": len(tasks.tasks)}
```

This is useful for:
- Graceful shutdown handling (wait for all background tasks to complete before stopping)
- Queue monitoring and observability

## Related
- Discussion: https://github.com/Kludex/starlette/discussions/2546
- Closes #2542

## Test Plan
- [x] Added `test_tasks_removed_after_execution` to verify tasks list is empty after execution
- [x] All existing background task tests pass