### PR TITLE
Fix CORSMiddleware to return explicit origin with Authorization header

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -170,7 +170,6 @@ class CORSMiddleware:
         if self.allow_all_origins and (has_cookie or has_authorization):
             self.allow_explicit_origin(headers, origin)
 
-
         # If we only allow specific origins, then we have to mirror back
         # the Origin header in the response.
         elif not self.allow_all_origins and self.is_allowed_origin(origin=origin):

--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -160,13 +160,16 @@ class CORSMiddleware:
         message.setdefault("headers", [])
         headers = MutableHeaders(scope=message)
         headers.update(self.simple_headers)
+
         origin = request_headers["Origin"]
         has_cookie = "cookie" in request_headers
+        has_authorization = "authorization" in request_headers
 
-        # If request includes any cookie headers, then we must respond
-        # with the specific origin instead of '*'.
-        if self.allow_all_origins and has_cookie:
+        # If request includes credentials (cookies or authorization headers),
+        # then we must respond with the specific origin instead of '*'.
+        if self.allow_all_origins and (has_cookie or has_authorization):
             self.allow_explicit_origin(headers, origin)
+
 
         # If we only allow specific origins, then we have to mirror back
         # the Origin header in the response.


### PR DESCRIPTION
Fixes #1832.

When `allow_credentials` is enabled and a request includes an `Authorization`
header, CORSMiddleware was returning `Access-Control-Allow-Origin: *`, which
is rejected by browsers for credentialed requests.

This change mirrors the existing cookie-based behavior and ensures an explicit
origin is returned when Authorization headers are present.

Tests were run locally and pass.
