### PR TITLE
Add WebTransport support and API

### DIFF
--- a/docs/webtransport.md
+++ b/docs/webtransport.md
@@ -1,0 +1,92 @@
+
+Starlette includes a `WebTransport` class that manages WebTransport sessions, allowing for bidirectional streams and unreliable datagrams over HTTP/3.
+
+### WebTransport
+
+Signature: `WebTransport(scope, receive, send)`
+
+```python
+from starlette.webtransport import WebTransport
+
+
+async def app(scope, receive, send):
+    transport = WebTransport(scope=scope, receive=receive, send=send)
+    await transport.accept()
+    async for data in transport.iter_datagrams():
+        await transport.send_datagram(data)
+    await transport.close()
+```
+
+WebTransport connections present a mapping interface, so you can use them in the same way as a `scope`.
+
+#### URL
+
+The connection URL is accessed as `transport.url`.
+
+#### Headers
+
+Headers are exposed as an immutable, case-insensitive, multi-dict.
+For example: `transport.headers['user-agent']`
+
+#### Query Parameters
+
+Query parameters are exposed as an immutable multi-dict.
+For example: `transport.query_params['search']`
+
+#### Path Parameters
+
+Router path parameters are exposed as a dictionary interface.
+For example: `transport.path_params['username']`
+
+### Accepting the connection
+
+* `await transport.accept(headers=None)`
+
+### Datagrams (Unreliable)
+
+WebTransport supports sending and receiving unreliable datagrams (similar to UDP).
+
+* `await transport.send_datagram(data: bytes)`
+* `await transport.receive_datagram() -> bytes`
+* `async for data in transport.iter_datagrams()`
+
+### Streams (Reliable)
+
+WebTransport supports multiple reliable streams over a single connection. Starlette provides a `WebTransportStream` object for each stream.
+
+* `await transport.accept_stream() -> WebTransportStream`
+
+#### WebTransportStream
+
+Represents a single bidirectional or unidirectional stream.
+
+* `stream.stream_id`: The ID of the stream.
+* `await stream.receive_bytes() -> bytes`: Read data from the stream.
+* `await stream.send_bytes(data: bytes)`: Write data to the stream.
+* `await stream.close()`: Close the stream.
+
+### Closing the connection
+
+* `await transport.close(code=0, reason=None)`
+
+### Endpoints
+
+Starlette provides a `WebTransportEndpoint` base class for class-based views.
+
+```python
+from starlette.endpoints import WebTransportEndpoint
+from starlette.webtransport import WebTransport
+
+class EchoTransport(WebTransportEndpoint):
+    async def on_connect(self, transport: WebTransport) -> None:
+        await transport.accept()
+    
+    async def on_datagram_receive(self, transport: WebTransport, data: bytes) -> None:
+        await transport.send_datagram(data)
+        
+    async def on_stream_receive(self, transport: WebTransport, stream_id: int, data: bytes, stream_ended: bool) -> None:
+        # Echo data back on the same stream
+        stream = transport._streams.get(stream_id)
+        if stream:
+            await stream.send_bytes(data)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Requests: "requests.md"
       - Responses: "responses.md"
       - WebSockets: "websockets.md"
+      - WebTransport: "webtransport.md"
       - Routing: "routing.md"
       - Endpoints: "endpoints.md"
       - Middleware: "middleware.md"

--- a/starlette/_exception_handler.py
+++ b/starlette/_exception_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
@@ -20,7 +20,11 @@ def _lookup_exception_handler(exc_handlers: ExceptionHandlers, exc: Exception) -
     return None
 
 
-def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket) -> ASGIApp:
+if TYPE_CHECKING:
+    from starlette.webtransport import WebTransport
+
+
+def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket | WebTransport) -> ASGIApp:
     exception_handlers: ExceptionHandlers
     status_handlers: StatusHandlers
     try:

--- a/starlette/endpoints.py
+++ b/starlette/endpoints.py
@@ -126,7 +126,7 @@ class WebSocketEndpoint:
 
 class WebTransportEndpoint:
     """Base class for WebTransport endpoints.
-    
+
     Override the on_connect, on_stream_receive, on_datagram_receive, and
     on_disconnect methods to handle WebTransport lifecycle events.
     """
@@ -142,14 +142,15 @@ class WebTransportEndpoint:
 
     async def dispatch(self) -> None:
         import anyio
+
         session = WebTransport(self.scope, receive=self.receive, send=self.send)
         await self.on_connect(session)
 
-        async def datagram_loop():
+        async def datagram_loop() -> None:
             async for data in session.iter_datagrams():
                 await self.on_datagram_receive(session, data)
 
-        async def stream_reader(stream):
+        async def stream_reader(stream: Any) -> None:
             try:
                 while True:
                     data = await stream.receive_bytes()
@@ -161,7 +162,7 @@ class WebTransportEndpoint:
                 # Signal stream end
                 await self.on_stream_receive(session, stream.stream_id, b"", True)
 
-        async def stream_accept_loop(task_group):
+        async def stream_accept_loop(task_group: Any) -> None:
             while True:
                 try:
                     stream = await session.accept_stream()
@@ -175,14 +176,14 @@ class WebTransportEndpoint:
                 tg.start_soon(datagram_loop)
                 tg.start_soon(stream_accept_loop, tg)
         except Exception:
-             # Connection closed or error
-             pass
+            # Connection closed or error
+            pass
         finally:
             await self.on_disconnect(session)
 
     async def on_connect(self, session: WebTransport) -> None:
         """Override to handle an incoming WebTransport connection.
-        
+
         Default implementation accepts the connection.
         """
         await session.accept()
@@ -201,4 +202,3 @@ class WebTransportEndpoint:
 
     async def on_disconnect(self, session: WebTransport) -> None:
         """Override to handle a disconnecting WebTransport session."""
-

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -83,7 +83,7 @@ class HTTPConnection(Mapping[str, Any], Generic[StateT]):
     """
 
     def __init__(self, scope: Scope, receive: Receive | None = None) -> None:
-        assert scope["type"] in ("http", "websocket")
+        assert scope["type"] in ("http", "websocket", "webtransport")
         self.scope = scope
 
     def __getitem__(self, key: str) -> Any:

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -24,7 +24,7 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
-from starlette.webtransport import WebTransport, WebTransportClose
+from starlette.webtransport import WebTransport
 
 
 class NoMatchFound(Exception):
@@ -451,11 +451,7 @@ class WebTransportRoute(BaseRoute):
         await self.app(scope, receive, send)
 
     def __eq__(self, other: Any) -> bool:
-        return (
-            isinstance(other, WebTransportRoute)
-            and self.path == other.path
-            and self.endpoint == other.endpoint
-        )
+        return isinstance(other, WebTransportRoute) and self.path == other.path and self.endpoint == other.endpoint
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self.path!r}, name={self.name!r})"

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -26,4 +26,3 @@ HTTPExceptionHandler = Callable[["Request", Exception], "Response | Awaitable[Re
 WebSocketExceptionHandler = Callable[["WebSocket", Exception], Awaitable[None]]
 WebTransportExceptionHandler = Callable[["WebTransport", Exception], Awaitable[None]]
 ExceptionHandler = HTTPExceptionHandler | WebSocketExceptionHandler
-

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
     from starlette.responses import Response
     from starlette.websockets import WebSocket
+    from starlette.webtransport import WebTransport
 
 AppType = TypeVar("AppType")
 
@@ -23,4 +24,6 @@ Lifespan = StatelessLifespan[AppType] | StatefulLifespan[AppType]
 
 HTTPExceptionHandler = Callable[["Request", Exception], "Response | Awaitable[Response]"]
 WebSocketExceptionHandler = Callable[["WebSocket", Exception], Awaitable[None]]
+WebTransportExceptionHandler = Callable[["WebTransport", Exception], Awaitable[None]]
 ExceptionHandler = HTTPExceptionHandler | WebSocketExceptionHandler
+

--- a/starlette/webtransport.py
+++ b/starlette/webtransport.py
@@ -1,14 +1,14 @@
 """
 WebTransport connection handling.
 
-This module provides WebTransport support for ASGI applications, similar to
-how websockets.py provides WebSocket support.
+This module provides WebTransport support for Starlette, aligning with the
+developer-friendly API design.
 """
 from __future__ import annotations
 
 import enum
-from collections.abc import Iterable
-from typing import Any
+import asyncio
+from typing import AsyncIterator, Dict, Optional, List
 
 from starlette.requests import HTTPConnection
 from starlette.types import Message, Receive, Scope, Send
@@ -29,11 +29,58 @@ class WebTransportDisconnect(Exception):
         self.reason = reason or ""
 
 
-class WebTransport(HTTPConnection):
-    """Represents a WebTransport connection.
+class WebTransportStream:
+    """Represents a single reliable stream within the session."""
     
-    Provides methods for accepting connections, sending/receiving data
-    on streams, and sending/receiving datagrams.
+    def __init__(self, transport: "WebTransport", stream_id: int) -> None:
+        self._transport = transport
+        self._stream_id = stream_id
+        self._receive_queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._read_closed = False
+        self._write_closed = False
+
+    @property
+    def stream_id(self) -> int:
+        return self._stream_id
+
+    async def receive_bytes(self) -> bytes:
+        """Reads data from the stream."""
+        if self._read_closed and self._receive_queue.empty():
+             raise WebTransportDisconnect(0, "Stream closed")
+             
+        try:
+            data = await self._receive_queue.get()
+            if data is None: # Sentinel for closed
+                self._read_closed = True
+                raise WebTransportDisconnect(0, "Stream closed")
+            return data
+        except RuntimeError:
+            # Queue might be closed
+             raise WebTransportDisconnect(0, "Connection closed")
+
+    async def send_bytes(self, data: bytes) -> None:
+        """Writes data to the stream."""
+        if self._write_closed:
+            raise RuntimeError("Stream is closed for writing")
+        
+        # We assume sending doesn't close the stream automatically unless specifically requested?
+        # The design doc says "close() -> Closes this specific stream".
+        # So send_bytes just sends.
+        await self._transport._send_stream_data(self._stream_id, data, finish=False)
+
+    async def close(self) -> None:
+        """Closes this specific stream without closing the session."""
+        self._write_closed = True
+        # Send a FIN with empty data
+        await self._transport._send_stream_data(self._stream_id, b"", finish=True)
+
+
+class WebTransport(HTTPConnection):
+    """
+    Represents a WebTransport connection.
+    
+    Handles the session handshake and acts as a factory/manager for 
+    streams and datagrams.
     """
     
     def __init__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -43,167 +90,148 @@ class WebTransport(HTTPConnection):
         self._send = send
         self.client_state = WebTransportState.CONNECTING
         self.application_state = WebTransportState.CONNECTING
-
-    @property
-    def session_id(self) -> int:
-        """Get the WebTransport session ID."""
-        return self.scope.get("extensions", {}).get("webtransport", {}).get("session_id", 0)
-
-    async def receive(self) -> Message:
-        """Receive ASGI WebTransport messages, ensuring valid state transitions."""
-        if self.client_state == WebTransportState.CONNECTING:
-            message = await self._receive()
-            message_type = message["type"]
-            if message_type == "webtransport.connect":
-                self.client_state = WebTransportState.CONNECTED
-            return message
-            
-        elif self.client_state == WebTransportState.CONNECTED:
-            message = await self._receive()
-            message_type = message["type"]
-            if message_type == "webtransport.disconnect":
-                self.client_state = WebTransportState.DISCONNECTED
-            return message
-            
-        else:
-            raise RuntimeError(
-                'Cannot receive on a WebTransport connection in the "%s" state.'
-                % self.client_state.name
-            )
-
-    async def send(self, message: Message) -> None:
-        """Send ASGI WebTransport messages, ensuring valid state transitions."""
-        if self.application_state == WebTransportState.CONNECTING:
-            message_type = message["type"]
-            if message_type == "webtransport.accept":
-                self.application_state = WebTransportState.CONNECTED
-            elif message_type == "webtransport.close":
-                self.application_state = WebTransportState.DISCONNECTED
-            else:
-                raise RuntimeError(
-                    f'Cannot send "{message_type}" while connecting. '
-                    'Call accept() or close() first.'
-                )
-            await self._send(message)
-            
-        elif self.application_state == WebTransportState.CONNECTED:
-            message_type = message["type"]
-            if message_type == "webtransport.close":
-                self.application_state = WebTransportState.DISCONNECTED
-            await self._send(message)
-            
-        else:
-            raise RuntimeError(
-                'Cannot send on a WebTransport connection in the "%s" state.'
-                % self.application_state.name
-            )
-
-    async def accept(
-        self,
-        headers: Iterable[tuple[bytes, bytes]] | None = None,
-    ) -> None:
-        """Accept the WebTransport connection.
         
-        Args:
-            headers: Optional additional headers to send with the accept response.
-        """
+        # Multiplexing structures
+        self._streams: Dict[int, WebTransportStream] = {}
+        self._accepted_streams_queue: asyncio.Queue[WebTransportStream] = asyncio.Queue()
+        self._datagram_queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._reader_task: Optional[asyncio.Task] = None
+
+    async def accept(self) -> None:
+        """Accepts the WebTransport session."""
         if self.application_state != WebTransportState.CONNECTING:
-            raise RuntimeError(
-                'WebTransport connection cannot be accepted in the "%s" state.'
-                % self.application_state.name
-            )
-        
-        message: Message = {"type": "webtransport.accept"}
-        if headers is not None:
-            message["headers"] = list(headers)
-        await self.send(message)
+            raise RuntimeError('Cannot accept connection in %s state' % self.application_state)
 
-    def _raise_on_disconnect(self, message: Message) -> None:
-        """Raise WebTransportDisconnect if message is a disconnect."""
-        if message["type"] == "webtransport.disconnect":
-            raise WebTransportDisconnect()
-
-    async def receive_stream_data(self) -> tuple[int, bytes, bool]:
-        """Receive data from a WebTransport stream.
+        await self._send({"type": "webtransport.accept"})
+        self.application_state = WebTransportState.CONNECTED
+        self.client_state = WebTransportState.CONNECTED
         
-        Returns:
-            A tuple of (stream_id, data, is_finished).
+        # Start background reader for multiplexing
+        self._reader_task = asyncio.create_task(self._reader_loop())
+
+    async def close(self, code: int = 0, reason: str = "") -> None:
+        """Closes the session."""
+        if self.application_state == WebTransportState.DISCONNECTED:
+            return
             
-        Raises:
-            WebTransportDisconnect: If the connection is closed.
-        """
-        while True:
-            message = await self.receive()
-            self._raise_on_disconnect(message)
-            
-            if message["type"] == "webtransport.stream.receive":
-                stream_id = message["stream_id"]
-                data = message.get("data", b"")
-                more_body = message.get("more_body", True)
-                return stream_id, data, not more_body
-            # Ignore other message types and continue waiting
+        self.application_state = WebTransportState.DISCONNECTED
+        await self._send({
+            "type": "webtransport.close",
+            "code": code,
+            "reason": reason
+        })
+        
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+
+    async def send_datagram(self, data: bytes) -> None:
+        """Sends a raw datagram."""
+        if self.application_state != WebTransportState.CONNECTED:
+            raise RuntimeError("Connection is not connected")
+        await self._send({
+            "type": "webtransport.datagram.send",
+            "data": data
+        })
 
     async def receive_datagram(self) -> bytes:
-        """Receive an unreliable datagram.
-        
-        Returns:
-            The datagram data.
-            
-        Raises:
-            WebTransportDisconnect: If the connection is closed.
-        """
-        while True:
-            message = await self.receive()
-            self._raise_on_disconnect(message)
-            
-            if message["type"] == "webtransport.datagram.receive":
-                return message.get("data", b"")
-            # Ignore other message types and continue waiting
+        """Waits for and returns the next datagram."""
+        if self.client_state == WebTransportState.DISCONNECTED and self._datagram_queue.empty():
+             raise WebTransportDisconnect()
+             
+        data = await self._datagram_queue.get()
+        if data is None:
+            raise WebTransportDisconnect()
+        return data
 
-    async def send_stream_data(
-        self,
-        stream_id: int,
-        data: bytes,
-        finish: bool = False,
-    ) -> None:
-        """Send data on a WebTransport stream.
-        
-        Args:
-            stream_id: The QUIC stream ID.
-            data: The data to send.
-            finish: If True, signal the end of the stream (FIN).
-        """
-        await self.send({
+    async def iter_datagrams(self) -> AsyncIterator[bytes]:
+        """Async iterator for incoming datagrams."""
+        try:
+            while True:
+                yield await self.receive_datagram()
+        except WebTransportDisconnect:
+            pass
+
+    async def accept_stream(self) -> WebTransportStream:
+        """Waits for the client to open a stream."""
+        if self.client_state == WebTransportState.DISCONNECTED and self._accepted_streams_queue.empty():
+             raise WebTransportDisconnect()
+             
+        stream = await self._accepted_streams_queue.get()
+        if stream is None:
+            raise WebTransportDisconnect()
+        return stream
+
+    async def create_bidirectional_stream(self) -> WebTransportStream:
+        """Initiates a new bidirectional stream to the client."""
+        # TODO: Need protocol support to allocate Stream IDs from server side
+        raise NotImplementedError("Server-initiated bidirectional streams are not yet supported")
+
+    async def create_unidirectional_stream(self) -> WebTransportStream:
+        """Initiates a new unidirectional stream to the client."""
+        raise NotImplementedError("Server-initiated unidirectional streams are not yet supported")
+
+    # API Internal Methods
+    
+    async def _send_stream_data(self, stream_id: int, data: bytes, finish: bool) -> None:
+        if self.application_state != WebTransportState.CONNECTED:
+            raise RuntimeError("Connection is not connected")
+            
+        await self._send({
             "type": "webtransport.stream.send",
             "stream_id": stream_id,
             "data": data,
-            "finish": finish,
+            "finish": finish
         })
 
-    async def send_datagram(self, data: bytes) -> None:
-        """Send an unreliable datagram.
-        
-        Args:
-            data: The datagram data to send.
-        """
-        await self.send({
-            "type": "webtransport.datagram.send",
-            "data": data,
-        })
-
-    async def close(self, code: int = 0, reason: str | None = None) -> None:
-        """Close the WebTransport connection.
-        
-        Args:
-            code: Optional close code.
-            reason: Optional close reason.
-        """
-        message: Message = {"type": "webtransport.close"}
-        if code != 0:
-            message["code"] = code
-        if reason:
-            message["reason"] = reason
-        await self.send(message)
+    async def _reader_loop(self) -> None:
+        """Background task to read from ASGI receive and demultiplex."""
+        try:
+            while True:
+                message = await self._receive()
+                print(f"DEBUG: WebTransport reader received: {message['type']}")
+                msg_type = message["type"]
+                
+                if msg_type == "webtransport.datagram.receive":
+                    self._datagram_queue.put_nowait(message["data"])
+                    
+                elif msg_type == "webtransport.stream.receive":
+                    stream_id = message["stream_id"]
+                    data = message["data"]
+                    more_body = message.get("more_body", True)
+                    print(f"DEBUG: Reader stream {stream_id} data len={len(data)} more_body={more_body}")
+                    
+                    if stream_id not in self._streams:
+                        # New stream!
+                        stream = WebTransportStream(self, stream_id)
+                        self._streams[stream_id] = stream
+                        self._accepted_streams_queue.put_nowait(stream)
+                    
+                    stream = self._streams[stream_id]
+                    stream._receive_queue.put_nowait(data)
+                    
+                    if not more_body:
+                        # Stream ended
+                        stream._receive_queue.put_nowait(None) # Sentinel
+                        
+                elif msg_type == "webtransport.disconnect":
+                    self.client_state = WebTransportState.DISCONNECTED
+                    self._cleanup_queues()
+                    break
+                    
+        except Exception:
+            self.client_state = WebTransportState.DISCONNECTED
+            self._cleanup_queues()
+            
+    def _cleanup_queues(self):
+        """Unblock all waiters with sentinels."""
+        self._datagram_queue.put_nowait(None)
+        self._accepted_streams_queue.put_nowait(None)
+        for stream in self._streams.values():
+            stream._receive_queue.put_nowait(None)
 
 
 class WebTransportClose:
@@ -214,9 +242,4 @@ class WebTransportClose:
         self.reason = reason or ""
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        message: Message = {"type": "webtransport.close"}
-        if self.code != 0:
-            message["code"] = self.code
-        if self.reason:
-            message["reason"] = self.reason
-        await send(message)
+        await send({"type": "webtransport.close", "code": self.code, "reason": self.reason})

--- a/starlette/webtransport.py
+++ b/starlette/webtransport.py
@@ -1,0 +1,222 @@
+"""
+WebTransport connection handling.
+
+This module provides WebTransport support for ASGI applications, similar to
+how websockets.py provides WebSocket support.
+"""
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterable
+from typing import Any
+
+from starlette.requests import HTTPConnection
+from starlette.types import Message, Receive, Scope, Send
+
+
+class WebTransportState(enum.Enum):
+    """State of a WebTransport connection."""
+    CONNECTING = 0
+    CONNECTED = 1
+    DISCONNECTED = 2
+
+
+class WebTransportDisconnect(Exception):
+    """Raised when a WebTransport connection is disconnected."""
+    
+    def __init__(self, code: int = 0, reason: str | None = None) -> None:
+        self.code = code
+        self.reason = reason or ""
+
+
+class WebTransport(HTTPConnection):
+    """Represents a WebTransport connection.
+    
+    Provides methods for accepting connections, sending/receiving data
+    on streams, and sending/receiving datagrams.
+    """
+    
+    def __init__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        super().__init__(scope)
+        assert scope["type"] == "webtransport"
+        self._receive = receive
+        self._send = send
+        self.client_state = WebTransportState.CONNECTING
+        self.application_state = WebTransportState.CONNECTING
+
+    @property
+    def session_id(self) -> int:
+        """Get the WebTransport session ID."""
+        return self.scope.get("extensions", {}).get("webtransport", {}).get("session_id", 0)
+
+    async def receive(self) -> Message:
+        """Receive ASGI WebTransport messages, ensuring valid state transitions."""
+        if self.client_state == WebTransportState.CONNECTING:
+            message = await self._receive()
+            message_type = message["type"]
+            if message_type == "webtransport.connect":
+                self.client_state = WebTransportState.CONNECTED
+            return message
+            
+        elif self.client_state == WebTransportState.CONNECTED:
+            message = await self._receive()
+            message_type = message["type"]
+            if message_type == "webtransport.disconnect":
+                self.client_state = WebTransportState.DISCONNECTED
+            return message
+            
+        else:
+            raise RuntimeError(
+                'Cannot receive on a WebTransport connection in the "%s" state.'
+                % self.client_state.name
+            )
+
+    async def send(self, message: Message) -> None:
+        """Send ASGI WebTransport messages, ensuring valid state transitions."""
+        if self.application_state == WebTransportState.CONNECTING:
+            message_type = message["type"]
+            if message_type == "webtransport.accept":
+                self.application_state = WebTransportState.CONNECTED
+            elif message_type == "webtransport.close":
+                self.application_state = WebTransportState.DISCONNECTED
+            else:
+                raise RuntimeError(
+                    f'Cannot send "{message_type}" while connecting. '
+                    'Call accept() or close() first.'
+                )
+            await self._send(message)
+            
+        elif self.application_state == WebTransportState.CONNECTED:
+            message_type = message["type"]
+            if message_type == "webtransport.close":
+                self.application_state = WebTransportState.DISCONNECTED
+            await self._send(message)
+            
+        else:
+            raise RuntimeError(
+                'Cannot send on a WebTransport connection in the "%s" state.'
+                % self.application_state.name
+            )
+
+    async def accept(
+        self,
+        headers: Iterable[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        """Accept the WebTransport connection.
+        
+        Args:
+            headers: Optional additional headers to send with the accept response.
+        """
+        if self.application_state != WebTransportState.CONNECTING:
+            raise RuntimeError(
+                'WebTransport connection cannot be accepted in the "%s" state.'
+                % self.application_state.name
+            )
+        
+        message: Message = {"type": "webtransport.accept"}
+        if headers is not None:
+            message["headers"] = list(headers)
+        await self.send(message)
+
+    def _raise_on_disconnect(self, message: Message) -> None:
+        """Raise WebTransportDisconnect if message is a disconnect."""
+        if message["type"] == "webtransport.disconnect":
+            raise WebTransportDisconnect()
+
+    async def receive_stream_data(self) -> tuple[int, bytes, bool]:
+        """Receive data from a WebTransport stream.
+        
+        Returns:
+            A tuple of (stream_id, data, is_finished).
+            
+        Raises:
+            WebTransportDisconnect: If the connection is closed.
+        """
+        while True:
+            message = await self.receive()
+            self._raise_on_disconnect(message)
+            
+            if message["type"] == "webtransport.stream.receive":
+                stream_id = message["stream_id"]
+                data = message.get("data", b"")
+                more_body = message.get("more_body", True)
+                return stream_id, data, not more_body
+            # Ignore other message types and continue waiting
+
+    async def receive_datagram(self) -> bytes:
+        """Receive an unreliable datagram.
+        
+        Returns:
+            The datagram data.
+            
+        Raises:
+            WebTransportDisconnect: If the connection is closed.
+        """
+        while True:
+            message = await self.receive()
+            self._raise_on_disconnect(message)
+            
+            if message["type"] == "webtransport.datagram.receive":
+                return message.get("data", b"")
+            # Ignore other message types and continue waiting
+
+    async def send_stream_data(
+        self,
+        stream_id: int,
+        data: bytes,
+        finish: bool = False,
+    ) -> None:
+        """Send data on a WebTransport stream.
+        
+        Args:
+            stream_id: The QUIC stream ID.
+            data: The data to send.
+            finish: If True, signal the end of the stream (FIN).
+        """
+        await self.send({
+            "type": "webtransport.stream.send",
+            "stream_id": stream_id,
+            "data": data,
+            "finish": finish,
+        })
+
+    async def send_datagram(self, data: bytes) -> None:
+        """Send an unreliable datagram.
+        
+        Args:
+            data: The datagram data to send.
+        """
+        await self.send({
+            "type": "webtransport.datagram.send",
+            "data": data,
+        })
+
+    async def close(self, code: int = 0, reason: str | None = None) -> None:
+        """Close the WebTransport connection.
+        
+        Args:
+            code: Optional close code.
+            reason: Optional close reason.
+        """
+        message: Message = {"type": "webtransport.close"}
+        if code != 0:
+            message["code"] = code
+        if reason:
+            message["reason"] = reason
+        await self.send(message)
+
+
+class WebTransportClose:
+    """ASGI application that closes a WebTransport connection."""
+    
+    def __init__(self, code: int = 0, reason: str | None = None) -> None:
+        self.code = code
+        self.reason = reason or ""
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        message: Message = {"type": "webtransport.close"}
+        if self.code != 0:
+            message["code"] = self.code
+        if self.reason:
+            message["reason"] = self.reason
+        await send(message)

--- a/starlette/webtransport.py
+++ b/starlette/webtransport.py
@@ -192,7 +192,6 @@ class WebTransport(HTTPConnection):
         try:
             while True:
                 message = await self._receive()
-                print(f"DEBUG: WebTransport reader received: {message['type']}")
                 msg_type = message["type"]
                 
                 if msg_type == "webtransport.datagram.receive":
@@ -202,7 +201,6 @@ class WebTransport(HTTPConnection):
                     stream_id = message["stream_id"]
                     data = message["data"]
                     more_body = message.get("more_body", True)
-                    print(f"DEBUG: Reader stream {stream_id} data len={len(data)} more_body={more_body}")
                     
                     if stream_id not in self._streams:
                         # New stream!

--- a/tests/test_webtransport.py
+++ b/tests/test_webtransport.py
@@ -1,0 +1,80 @@
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+from starlette.webtransport import WebTransport, WebTransportDisconnect
+
+def test_webtransport_accept(test_client_factory):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        transport = WebTransport(scope, receive=receive, send=send)
+        await transport.accept()
+        await transport.close()
+
+    client = test_client_factory(app)
+    with client.webtransport_connect("/") as session:
+        pass
+
+def test_webtransport_datagrams(test_client_factory):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        transport = WebTransport(scope, receive=receive, send=send)
+        await transport.accept()
+        data = await transport.receive_datagram()
+        await transport.send_datagram(b"echo: " + data)
+        await transport.close()
+
+    client = test_client_factory(app)
+    with client.webtransport_connect("/") as session:
+        session.send_datagram(b"hello")
+        message = session.receive()
+        assert message["type"] == "webtransport.datagram.send"
+        assert message["data"] == b"echo: hello"
+
+def test_webtransport_streams(test_client_factory):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        transport = WebTransport(scope, receive=receive, send=send)
+        await transport.accept()
+        stream = await transport.accept_stream()
+        data = await stream.receive_bytes()
+        await stream.send_bytes(b"echo: " + data)
+        await stream.close()
+        await transport.close()
+
+    client = test_client_factory(app)
+    with client.webtransport_connect("/") as session:
+        session.send_stream_data(stream_id=0, data=b"hello", end_stream=True)
+        
+        # We might receive multiple chunks if implementing flow control, but for test
+        message = session.receive()
+        assert message["type"] == "webtransport.stream.send"
+        assert message["stream_id"] == 0
+        assert message["data"] == b"echo: hello"
+        
+        # Expect FIN
+        message = session.receive()
+        assert message["type"] == "webtransport.stream.send"
+        assert message["data"] == b""
+        assert message["finish"] is True
+
+def test_webtransport_disconnect(test_client_factory):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        transport = WebTransport(scope, receive=receive, send=send)
+        await transport.accept()
+        try:
+            await transport.receive_datagram()
+        except WebTransportDisconnect:
+            pass # Expected
+        
+    client = test_client_factory(app)
+    with client.webtransport_connect("/") as session:
+        session.close()
+
+def test_webtransport_reject(test_client_factory):
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        transport = WebTransport(scope, receive=receive, send=send)
+        await transport.close(code=403)
+
+    client = test_client_factory(app)
+    with pytest.raises(WebTransportDisconnect) as exc:
+        with client.webtransport_connect("/"):
+             pass
+    assert exc.value.code == 403


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Adds WebTransport support to Starlette, providing an API for bidirectional streams and datagrams over HTTP/3. This follows the ASGI WebTransport specification.

Main changes:
- Add `WebTransport` and `WebTransportStream` classes in `starlette.webtransport`.
- Add `WebTransportRoute` for path-based routing of `WebTransport` connections.
- Add `WebTransportEndpoint` base class for class-based views.
- Extend `HTTPConnection` to support webtransport scope.
- Add documentation in docs/webtransport.md.
- Add tests


Example:
```py
from starlette.webtransport import WebTransport
async def app(scope, receive, send):
    transport = WebTransport(scope=scope, receive=receive, send=send)
    await transport.accept()
    async for data in transport.iter_datagrams():
        await transport.send_datagram(data)
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
