### PR TITLE
Fix CORS middleware to handle Authorization header

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -162,10 +162,11 @@ class CORSMiddleware:
         headers.update(self.simple_headers)
         origin = request_headers["Origin"]
         has_cookie = "cookie" in request_headers
+        has_authorization = "authorization" in request_headers
 
-        # If request includes any cookie headers, then we must respond
+        # If request includes any cookie headers or authorization header, then we must respond
         # with the specific origin instead of '*'.
-        if self.allow_all_origins and has_cookie:
+        if self.allow_all_origins and (has_cookie or has_authorization):
             self.allow_explicit_origin(headers, origin)
 
         # If we only allow specific origins, then we have to mirror back

--- a/tests/middleware/test_cors.py
+++ b/tests/middleware/test_cors.py
@@ -52,8 +52,17 @@ def test_cors_allow_all(
     assert response.headers["access-control-expose-headers"] == "X-Status"
     assert response.headers["access-control-allow-credentials"] == "true"
 
-    # Test standard credentialed response
+    # Test standard credentialed response with cookies
     headers = {"Origin": "https://example.org", "Cookie": "star_cookie=sugar"}
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["access-control-allow-origin"] == "https://example.org"
+    assert response.headers["access-control-expose-headers"] == "X-Status"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+    # Test standard credentialed response with Authorization header
+    headers = {"Origin": "https://example.org", "Authorization": "Bearer token"}
     response = client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "Homepage"
@@ -416,8 +425,16 @@ def test_cors_credentialed_requests_return_specific_origin(
     )
     client = test_client_factory(app)
 
-    # Test credentialed request
+    # Test credentialed request with cookie
     headers = {"Origin": "https://example.org", "Cookie": "star_cookie=sugar"}
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Homepage"
+    assert response.headers["access-control-allow-origin"] == "https://example.org"
+    assert "access-control-allow-credentials" not in response.headers
+
+    # Test credentialed request with Authorization header
+    headers = {"Origin": "https://example.org", "Authorization": "Bearer token"}
     response = client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "Homepage"
@@ -475,6 +492,11 @@ def test_cors_vary_header_is_properly_set_for_credentialed_request(
     client = test_client_factory(app)
 
     response = client.get("/", headers={"Cookie": "foo=bar", "Origin": "https://someplace.org"})
+    assert response.status_code == 200
+    assert response.headers["vary"] == "Accept-Encoding, Origin"
+
+    # Test with Authorization header
+    response = client.get("/", headers={"Authorization": "Bearer token", "Origin": "https://someplace.org"})
     assert response.status_code == 200
     assert response.headers["vary"] == "Accept-Encoding, Origin"
 


### PR DESCRIPTION
## Summary
- Fixes CORSMiddleware to check for `Authorization` headers in addition to cookies when determining whether to return specific origin vs wildcard
- Addresses issue #1832

## Background
When sending a CORS request with credentials (either cookies or Authorization header), the wildcard origin (`*`) is rejected by the browser according to the CORS specification. The middleware was correctly handling this for cookies, but not for Authorization headers.

Since token-based authentication (Bearer tokens) is widely used in modern APIs, the Authorization header should be treated the same as cookies when determining CORS behavior.

## Changes
1. **Code**: Added check for `authorization` header alongside the existing cookie check in `starlette/middleware/cors.py`
2. **Tests**: Added comprehensive test coverage for Authorization header behavior:
   - Test that Authorization header triggers explicit origin in response (like cookies do)
   - Test that Vary header is properly set with Authorization header
   - Test credentialed requests return specific origin

## Testing
All existing tests pass, and new tests verify the Authorization header behavior:
```
$ pytest tests/middleware/test_cors.py -xvs
17 passed in 0.09s
```

## CORS Specification Compliance
According to the CORS spec, when credentials are present in a request, the `Access-Control-Allow-Origin` response header cannot be `*` and must specify the exact origin. This applies to both:
- Cookie headers (already implemented)
- Authorization headers (now implemented)

Fixes #1832