### PR TITLE
Return explicit origin in CORS response when credentials are allowed

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -68,6 +68,7 @@ class CORSMiddleware:
         self.allow_headers = [h.lower() for h in allow_headers]
         self.allow_all_origins = allow_all_origins
         self.allow_all_headers = allow_all_headers
+        self.allow_credentials = allow_credentials
         self.preflight_explicit_allow_origin = preflight_explicit_allow_origin
         self.allow_origin_regex = compiled_allow_origin_regex
         self.allow_private_network = allow_private_network
@@ -161,15 +162,12 @@ class CORSMiddleware:
         headers = MutableHeaders(scope=message)
         headers.update(self.simple_headers)
         origin = request_headers["Origin"]
-        has_cookie = "cookie" in request_headers
 
-        # If request includes any cookie headers, then we must respond
-        # with the specific origin instead of '*'.
-        if self.allow_all_origins and has_cookie:
+        # If credentials are allowed, then we must respond with the specific origin instead of '*'.
+        if self.allow_all_origins and self.allow_credentials:
             self.allow_explicit_origin(headers, origin)
 
-        # If we only allow specific origins, then we have to mirror back
-        # the Origin header in the response.
+        # If we only allow specific origins, then we have to mirror back the Origin header in the response.
         elif not self.allow_all_origins and self.is_allowed_origin(origin=origin):
             self.allow_explicit_origin(headers, origin)
 


### PR DESCRIPTION
- Closes #1832.

When `allow_origins=["*"]` and `allow_credentials=True`, the simple response path now returns the explicit request origin instead of `*`. This aligns with the preflight path, which already does this since #1113.

The previous approach inspected request headers (cookies) to decide when to echo the origin. This is unreliable - the server can't observe the client's `credentials` mode from request headers alone. Instead, we use `allow_credentials` as the signal, same as [django-cors-headers](https://github.com/adamchainz/django-cors-headers/blob/45161f0c9439909f79595b7a0e0a3c1d372340c3/src/corsheaders/middleware.py#L111-L114) and [envoy-proxy](https://github.com/envoyproxy/envoy/blob/af4e593ae9d6c0e908fb4c591a18274887dc5f48/source/extensions/filters/http/cors/cors_filter.cc#L136-L139).

Supersedes #1824, #2506, #3127, #3134.