### PR TITLE
Handle null bytes in `StaticFiles` path

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -123,6 +123,9 @@ class StaticFiles:
                 raise HTTPException(status_code=404)
 
             raise exc
+        except ValueError:
+            # Null bytes or other invalid characters in the path.
+            raise HTTPException(status_code=400)
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -125,7 +125,7 @@ class StaticFiles:
             raise exc
         except ValueError:
             # Null bytes or other invalid characters in the path.
-            raise HTTPException(status_code=400)
+            raise HTTPException(status_code=404)
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -466,7 +466,7 @@ def test_staticfiles_null_byte_in_path(tmpdir: Path, test_client_factory: TestCl
     client = test_client_factory(app)
 
     response = client.get("/example%00.txt")
-    assert response.status_code == 400
+    assert response.status_code == 404
 
 
 def test_staticfiles_filename_too_long(tmpdir: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -460,6 +460,15 @@ def test_staticfiles_access_file_as_dir_returns_404(tmpdir: Path, test_client_fa
     assert response.text == "Not Found"
 
 
+def test_staticfiles_null_byte_in_path(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
+    routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
+    app = Starlette(routes=routes)
+    client = test_client_factory(app)
+
+    response = client.get("/example%00.txt")
+    assert response.status_code == 400
+
+
 def test_staticfiles_filename_too_long(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
     routes = [Mount("/", app=StaticFiles(directory=tmpdir), name="static")]
     app = Starlette(routes=routes)


### PR DESCRIPTION
A `%00` in the URL path gets decoded by uvicorn into a null byte, which causes `os.path.realpath()` to raise `ValueError` inside `lookup_path()`. This was unhandled, resulting in a 500. Now returns 404.