### PR TITLE
Include `bytes` unit in Content-Range header on 416 responses

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -369,7 +369,7 @@ class FileResponse(Response):
             except MalformedRangeHeader as exc:
                 return await PlainTextResponse(exc.content, status_code=400)(scope, receive, send)
             except RangeNotSatisfiable as exc:
-                response = PlainTextResponse(status_code=416, headers={"Content-Range": f"*/{exc.max_size}"})
+                response = PlainTextResponse(status_code=416, headers={"Content-Range": f"bytes */{exc.max_size}"})
                 return await response(scope, receive, send)
 
             if len(ranges) == 1:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -746,7 +746,7 @@ def test_file_response_range_head_max(file_response_client: TestClient) -> None:
 def test_file_response_range_416(file_response_client: TestClient) -> None:
     response = file_response_client.head("/", headers={"Range": f"bytes={len(README.encode('utf8')) + 1}-"})
     assert response.status_code == 416
-    assert response.headers["Content-Range"] == f"*/{len(README.encode('utf8'))}"
+    assert response.headers["Content-Range"] == f"bytes */{len(README.encode('utf8'))}"
 
 
 def test_file_response_only_support_bytes_range(file_response_client: TestClient) -> None:


### PR DESCRIPTION
Add missing `bytes` unit in `Content-Range` header on 416 responses per [RFC 9110 §14.4](https://httpwg.org/specs/rfc9110.html#field.content-range).

- Extracted from #3105.