### PR TITLE
Set `Content-Type` instead of `Content-Range` on multi-range responses

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -425,7 +425,7 @@ class FileResponse(Response):
         content_length, header_generator = self.generate_multipart(
             ranges, boundary, file_size, self.headers["content-type"]
         )
-        self.headers["content-range"] = f"multipart/byteranges; boundary={boundary}"
+        self.headers["content-type"] = f"multipart/byteranges; boundary={boundary}"
         self.headers["content-length"] = str(content_length)
         await send({"type": "http.response.start", "status": 206, "headers": self.raw_headers})
         if send_header_only:


### PR DESCRIPTION
Set `Content-Type` to `multipart/byteranges; boundary=...` and leave `Content-Range` unset on multi-range responses per [RFC 9110 §14.6](https://httpwg.org/specs/rfc9110.html#partial.multipart).

Extracted from #3105.

Co-authored-by: Victor Westerhuis <victor.westerhuis@alliander.com>