### PR TITLE
Enable autoescape by default in Jinja2Templates

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -129,7 +129,8 @@ def test_homepage():
 ## Customizing Jinja2 Environment
 
 `Jinja2Templates` accepts all options supported by Jinja2 `Environment`.
-This will allow more control over the `Environment` instance created by Starlette.
+Enabling `autoescape` by default for HTML/XML files using `jinja2.select_autoescape()` ensures a secure baseline against XSS vulnerabilities.
+These options can be customized or overridden by passing them as keyword arguments.
 
 For the list of options available to `Environment` you can check Jinja2 documentation [here](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment)
 

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -71,6 +71,7 @@ class Jinja2Templates:
         directory: str | PathLike[str] | Sequence[str | PathLike[str]],
         *,
         context_processors: list[Callable[[Request], dict[str, Any]]] | None = None,
+        **env_options: Any,
     ) -> None: ...
 
     @overload
@@ -79,6 +80,7 @@ class Jinja2Templates:
         *,
         env: jinja2.Environment,
         context_processors: list[Callable[[Request], dict[str, Any]]] | None = None,
+        **env_options: Any,
     ) -> None: ...
 
     def __init__(
@@ -87,12 +89,14 @@ class Jinja2Templates:
         *,
         context_processors: list[Callable[[Request], dict[str, Any]]] | None = None,
         env: jinja2.Environment | None = None,
+        **env_options: Any,
     ) -> None:
         assert bool(directory) ^ bool(env), "either 'directory' or 'env' arguments must be passed"
         self.context_processors = context_processors or []
         if directory is not None:
+            env_options.setdefault("autoescape", jinja2.select_autoescape())
             loader = jinja2.FileSystemLoader(directory)
-            self.env = jinja2.Environment(loader=loader)
+            self.env = jinja2.Environment(loader=loader, **env_options)
         elif env is not None:  # pragma: no branch
             self.env = env
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -34,6 +34,28 @@ def test_templates(tmpdir: Path, test_client_factory: TestClientFactory) -> None
     assert set(response.context.keys()) == {"request"}  # type: ignore
 
 
+def test_templates_autoescape(tmpdir: Path) -> None:
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello, {{ name }}")
+
+    templates = Jinja2Templates(directory=str(tmpdir))
+    template = templates.get_template("index.html")
+    content = template.render(name="<script>alert('XSS')</script>")
+    assert content == "Hello, &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;"
+
+
+def test_templates_autoescape_disabled(tmpdir: Path) -> None:
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("Hello, {{ name }}")
+
+    templates = Jinja2Templates(directory=str(tmpdir), autoescape=False)
+    template = templates.get_template("index.html")
+    content = template.render(name="<script>alert('XSS')</script>")
+    assert content == "Hello, <script>alert('XSS')</script>"
+
+
 def test_calls_context_processors(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     path = tmp_path / "index.html"
     path.write_text("<html>Hello {{ username }}</html>")
@@ -130,7 +152,7 @@ def test_templates_require_directory_or_environment() -> None:
 
 def test_templates_require_directory_or_environment_not_both() -> None:
     with pytest.raises(AssertionError, match="either 'directory' or 'env' arguments must be passed"):
-        Jinja2Templates(directory="dir", env=jinja2.Environment())  # type: ignore[call-overload]
+        Jinja2Templates(directory="dir", env=jinja2.Environment())
 
 
 def test_templates_with_directory(tmpdir: Path) -> None:


### PR DESCRIPTION
# Summary

Noticed that `Jinja2Templates` currently defaults to having `autoescape` disabled. It puts the burden on the developer to remember to enable it, which I've seen lead to XSS vulnerabilities in applications that render user-provided content.

While investigating, I also discovered that `Jinja2Templates` was missing support for `**env_options` in its constructor, making it difficult to customize the environment even though the documentation suggested it was supported.

Updated the implementation to:
- Use `jinja2.select_autoescape()` by default for HTML/XML files to ensure a secure baseline.
- Add support for `**env_options` in the `Jinja2Templates` constructor, allowing full customization of the Jinja2 environment.

### Changes
- Modified `Jinja2Templates.__init__` to accept and use `**env_options`.
- Enabled `autoescape` by default using `select_autoescape()` if not explicitly provided.
- Added test cases in `tests/test_templates.py` to verify both the secure default and the ability to override it.

# Checklist

- [x] Understood that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] Added a test for each change that was introduced, while I tried as much as possible to make a single atomic change.
- [x] Updated the documentation accordingly.