### PR TITLE
Enable `autoescape` by default in `Jinja2Templates`

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,17 +1,17 @@
 Starlette is not _strictly_ coupled to any particular templating engine, but
 Jinja2 provides an excellent choice.
 
-### Jinja2Templates
-
-Signature: `Jinja2Templates(directory, context_processors=None)` or `Jinja2Templates(env, context_processors=None)`
-
-* `directory` - A string, [os.Pathlike][pathlike] or a list of strings or [os.Pathlike][pathlike] denoting a directory path.
-* `env` - A preconfigured [`jinja2.Environment`](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment) instance.
-* `context_processors` - A list of functions that return a dictionary to add to the template context.
+??? abstract "API Reference"
+    ::: starlette.templating.Jinja2Templates
+        options:
+            parameter_headings: false
+            show_root_heading: true
+            heading_level: 3
+            filters:
+                - "__init__"
 
 Starlette provides a simple way to get `jinja2` configured. This is probably
-what you want to use by default. Autoescape is enabled by default for
-`.html`, `.htm`, and `.xml` templates using `jinja2.select_autoescape()`.
+what you want to use by default.
 
 ```python
 from starlette.applications import Starlette
@@ -73,6 +73,16 @@ env = jinja2.Environment(...)
 templates = Jinja2Templates(env=env)
 ```
 
+
+## Autoescape
+
+When using the `directory` argument, Starlette enables autoescape by default for
+`.html`, `.htm`, and `.xml` templates using [`jinja2.select_autoescape()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.select_autoescape).
+
+This protects against Cross-Site Scripting (XSS) vulnerabilities by escaping
+user-provided content before rendering it in the template. For example, if a user
+submits `<script>alert('XSS')</script>` as their name, it will be rendered as
+`&lt;script&gt;alert('XSS')&lt;/script&gt;` instead of being executed as JavaScript.
 
 ## Context processors
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -10,7 +10,7 @@ Signature: `Jinja2Templates(directory, context_processors=None)`
 
 Starlette provides a simple way to get `jinja2` configured. This is probably
 what you want to use by default. Autoescape is enabled by default for
-`.html`, `.htm`, `.svg`, and `.xml` templates using `jinja2.select_autoescape()`.
+`.html`, `.htm`, and `.xml` templates using `jinja2.select_autoescape()`.
 
 ```python
 from starlette.applications import Starlette

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -3,14 +3,14 @@ Jinja2 provides an excellent choice.
 
 ### Jinja2Templates
 
-Signature: `Jinja2Templates(directory, context_processors=None, **env_options)`
+Signature: `Jinja2Templates(directory, context_processors=None)`
 
 * `directory` - A string, [os.Pathlike][pathlike] or a list of strings or [os.Pathlike][pathlike] denoting a directory path.
 * `context_processors` - A list of functions that return a dictionary to add to the template context.
-* `**env_options` - Additional keyword arguments to pass to the Jinja2 environment.
 
 Starlette provides a simple way to get `jinja2` configured. This is probably
-what you want to use by default.
+what you want to use by default. Autoescape is enabled by default for
+`.html`, `.htm`, `.svg`, and `.xml` templates using `jinja2.select_autoescape()`.
 
 ```python
 from starlette.applications import Starlette
@@ -124,20 +124,6 @@ def test_homepage():
     assert response.status_code == 200
     assert response.template.name == 'index.html'
     assert "request" in response.context
-```
-
-## Customizing Jinja2 Environment
-
-`Jinja2Templates` accepts all options supported by Jinja2 `Environment`.
-This will allow more control over the `Environment` instance created by Starlette.
-
-For the list of options available to `Environment` you can check Jinja2 documentation [here](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment)
-
-```python
-from starlette.templating import Jinja2Templates
-
-
-templates = Jinja2Templates(directory='templates', autoescape=False, auto_reload=True)
 ```
 
 ## Asynchronous template rendering

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -3,9 +3,10 @@ Jinja2 provides an excellent choice.
 
 ### Jinja2Templates
 
-Signature: `Jinja2Templates(directory, context_processors=None)`
+Signature: `Jinja2Templates(directory, context_processors=None)` or `Jinja2Templates(env, context_processors=None)`
 
 * `directory` - A string, [os.Pathlike][pathlike] or a list of strings or [os.Pathlike][pathlike] denoting a directory path.
+* `env` - A preconfigured [`jinja2.Environment`](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment) instance.
 * `context_processors` - A list of functions that return a dictionary to add to the template context.
 
 Starlette provides a simple way to get `jinja2` configured. This is probably

--- a/starlette/templating.py
+++ b/starlette/templating.py
@@ -92,7 +92,7 @@ class Jinja2Templates:
         self.context_processors = context_processors or []
         if directory is not None:
             loader = jinja2.FileSystemLoader(directory)
-            self.env = jinja2.Environment(loader=loader)
+            self.env = jinja2.Environment(loader=loader, autoescape=jinja2.select_autoescape())
         elif env is not None:  # pragma: no branch
             self.env = env
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -40,7 +40,10 @@ def test_templates_autoescape(tmp_path: Path) -> None:
 
     templates = Jinja2Templates(directory=tmp_path)
     template = templates.get_template("index.html")
-    assert template.render(name="<script>alert('XSS')</script>") == "Hello, &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;"
+    assert (
+        template.render(name="<script>alert('XSS')</script>")
+        == "Hello, &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;"
+    )
 
 
 def test_calls_context_processors(tmp_path: Path, test_client_factory: TestClientFactory) -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -34,6 +34,15 @@ def test_templates(tmpdir: Path, test_client_factory: TestClientFactory) -> None
     assert set(response.context.keys()) == {"request"}  # type: ignore
 
 
+def test_templates_autoescape(tmp_path: Path) -> None:
+    path = tmp_path / "index.html"
+    path.write_text("Hello, {{ name }}")
+
+    templates = Jinja2Templates(directory=tmp_path)
+    template = templates.get_template("index.html")
+    assert template.render(name="<script>alert('XSS')</script>") == "Hello, &lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;"
+
+
 def test_calls_context_processors(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     path = tmp_path / "index.html"
     path.write_text("<html>Hello {{ username }}</html>")


### PR DESCRIPTION
- Use `jinja2.select_autoescape()` as the default when creating the Jinja2 environment from a directory.
- This is the [recommended secure baseline](https://jinja.palletsprojects.com/en/stable/api/) per Jinja2 documentation, and matches Flask's default behavior.
- Does not affect users who pass their own `env` — they remain in full control.
- Closes #3146.