### PR TITLE
Add `BaseResponse` class and `ContentT` generic to `Response`

### DIFF
--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -8,7 +8,7 @@ from starlette.middleware import Middleware, _MiddlewareFactory
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import BaseResponse
 from starlette.routing import BaseRoute, Router
 from starlette.types import ASGIApp, ExceptionHandler, Lifespan, Receive, Scope, Send
 
@@ -110,7 +110,7 @@ class Starlette:
     def add_route(
         self,
         path: str,
-        route: Callable[[Request], Awaitable[Response] | Response],
+        route: Callable[[Request], Awaitable[BaseResponse] | BaseResponse],
         methods: list[str] | None = None,
         name: str | None = None,
         include_in_schema: bool = True,

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -21,7 +21,7 @@ from starlette.datastructures import URL, Headers, URLPath
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, RedirectResponse, Response
+from starlette.responses import BaseResponse, PlainTextResponse, RedirectResponse
 from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
 
@@ -44,13 +44,13 @@ class Match(Enum):
 
 
 def request_response(
-    func: Callable[[Request], Awaitable[Response] | Response],
+    func: Callable[[Request], Awaitable[BaseResponse] | BaseResponse],
 ) -> ASGIApp:
     """
     Takes a function or coroutine `func(request) -> response`,
     and returns an ASGI application.
     """
-    f: Callable[[Request], Awaitable[Response]] = (
+    f: Callable[[Request], Awaitable[BaseResponse]] = (
         func if is_async_callable(func) else functools.partial(run_in_threadpool, func)
     )
 
@@ -723,7 +723,7 @@ class Router:
     def add_route(
         self,
         path: str,
-        endpoint: Callable[[Request], Awaitable[Response] | Response],
+        endpoint: Callable[[Request], Awaitable[BaseResponse] | BaseResponse],
         methods: Collection[str] | None = None,
         name: str | None = None,
         include_in_schema: bool = True,

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -13,7 +13,7 @@ import anyio.to_thread
 from starlette._utils import get_route_path
 from starlette.datastructures import URL, Headers
 from starlette.exceptions import HTTPException
-from starlette.responses import FileResponse, RedirectResponse, Response
+from starlette.responses import BaseResponse, FileResponse, RedirectResponse, Response
 from starlette.types import Receive, Scope, Send
 
 PathLike = Union[str, "os.PathLike[str]"]
@@ -106,7 +106,7 @@ class StaticFiles:
         route_path = get_route_path(scope)
         return os.path.normpath(os.path.join(*route_path.split("/")))
 
-    async def get_response(self, path: str, scope: Scope) -> Response:
+    async def get_response(self, path: str, scope: Scope) -> BaseResponse:
         """
         Returns an HTTP response, given the incoming path, method and request headers.
         """
@@ -175,7 +175,7 @@ class StaticFiles:
         stat_result: os.stat_result,
         scope: Scope,
         status_code: int = 200,
-    ) -> Response:
+    ) -> BaseResponse:
         request_headers = Headers(scope=scope)
 
         response = FileResponse(full_path, status_code=status_code, stat_result=stat_result)

--- a/starlette/types.py
+++ b/starlette/types.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from starlette.requests import Request
-    from starlette.responses import Response
+    from starlette.responses import BaseResponse
     from starlette.websockets import WebSocket
 
 AppType = TypeVar("AppType")
@@ -21,6 +21,6 @@ StatelessLifespan = Callable[[AppType], AbstractAsyncContextManager[None]]
 StatefulLifespan = Callable[[AppType], AbstractAsyncContextManager[Mapping[str, Any]]]
 Lifespan = StatelessLifespan[AppType] | StatefulLifespan[AppType]
 
-HTTPExceptionHandler = Callable[["Request", Exception], "Response | Awaitable[Response]"]
+HTTPExceptionHandler = Callable[["Request", Exception], "BaseResponse | Awaitable[BaseResponse]"]
 WebSocketExceptionHandler = Callable[["WebSocket", Exception], Awaitable[None]]
 ExceptionHandler = HTTPExceptionHandler | WebSocketExceptionHandler

--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Iterable
 from typing import Any, cast
 
 from starlette.requests import HTTPConnection, StateT
-from starlette.responses import Response
+from starlette.responses import BaseResponse
 from starlette.types import Message, Receive, Scope, Send
 
 
@@ -180,7 +180,7 @@ class WebSocket(HTTPConnection[StateT]):
     async def close(self, code: int = 1000, reason: str | None = None) -> None:
         await self.send({"type": "websocket.close", "code": code, "reason": reason or ""})
 
-    async def send_denial_response(self, response: Response) -> None:
+    async def send_denial_response(self, response: BaseResponse) -> None:
         if "websocket.http.response" in self.scope.get("extensions", {}):
             await response(self.scope, self.receive, self.send)
         else:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -13,7 +13,7 @@ from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import BaseResponse
 from starlette.routing import Mount
 from starlette.staticfiles import StaticFiles
 from tests.types import TestClientFactory
@@ -51,7 +51,7 @@ def test_staticfiles_head_with_middleware(tmpdir: Path, test_client_factory: Tes
     with open(path, "w") as file:
         file.write("x" * 100)
 
-    async def does_nothing_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
+    async def does_nothing_middleware(request: Request, call_next: RequestResponseEndpoint) -> BaseResponse:
         response = await call_next(request)
         return response
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -10,7 +10,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import BaseResponse, Response
 from starlette.routing import Route
 from starlette.templating import Jinja2Templates
 from tests.types import TestClientFactory
@@ -71,7 +71,7 @@ def test_template_with_middleware(tmpdir: Path, test_client_factory: TestClientF
         return templates.TemplateResponse(request, "index.html")
 
     class CustomMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> BaseResponse:
             return await call_next(request)
 
     app = Starlette(


### PR DESCRIPTION
Continuation of #2547.

Extract `BaseResponse` from `Response` to separate responses that use `render()` (`Response`, `HTMLResponse`, `JSONResponse`, etc.) from those that don't (`StreamingResponse`, `FileResponse`). Currently `StreamingResponse` and `FileResponse` inherit from `Response` but never call `render()` — they only use shared infrastructure (headers, cookies, status code).

`Response` is now `Response(BaseResponse, Generic[ContentT])`, and `JSONResponse` is `JSONResponse(Response[ContentT])`.

`StreamingResponse` and `FileResponse` inherit from `BaseResponse` directly, and call `super().__init__()` instead of manually setting attributes.

Breaking changes:
- `StreamingResponse` and `FileResponse` no longer inherit from `Response`.
- Type aliases that used `Response` now use `BaseResponse` (e.g. `HTTPExceptionHandler`, `RequestResponseEndpoint`).