### PR TITLE
Replace non-capturing groups in `scripts/sync-version` regex

### DIFF
--- a/scripts/sync-version
+++ b/scripts/sync-version
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?"
+SEMVER_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+[0-9A-Za-z-]+)?"
 CHANGELOG_VERSION=$(grep -o -E $SEMVER_REGEX docs/release-notes.md | head -1)
 VERSION=$(grep -o -E $SEMVER_REGEX starlette/__init__.py | head -1)
 if [ "$CHANGELOG_VERSION" != "$VERSION" ]; then


### PR DESCRIPTION
## Summary

Extended regular expressions (enabled via `grep -E`) don't support non-capturing groups under POSIX. Replace `(?:...)` with `(...)` since we don't use the captured groups anyway.

The warning was:

```
$ ./scripts/sync-version
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
grep: warning: ? at start of expression
```

Equivalent fix to https://github.com/Kludex/uvicorn/pull/2807.