### PR TITLE
Add 'route' reference to Mount child scope

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -413,6 +413,7 @@ class Mount(BaseRoute):
                     "app_root_path": scope.get("app_root_path", root_path),
                     "root_path": root_path + matched_path,
                     "endpoint": self.app,
+                    "route": self,
                 }
                 return Match.FULL, child_scope
         return Match.NONE, {}


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

When matching a mount point, record the `Mount` as scope["route"]

The purpose: when enriching logs with metadata, I would like to include the `name` of routes without having to re-traverse routes or rematch. Specifically, I'm focused on FastAPI endpoints and  `StaticFiles` right now.

For fastapi endpoints, this is already easy:
<img width="608" height="64" alt="image" src="https://github.com/user-attachments/assets/0c7c5bda-14bb-4af2-8a9a-09785e58af63" />
``` json
"route_definition": "internalapp.endpoints.devtools.devtools:log_alternate_name"
"route_name": "my_custom_name"
```

But for handling `StaticFiles`  mounts, this was the least intrusive way I could think to do it.
I'm open to other thoughts, especially if Mount is used more widely internally in a way that would make this a bad idea.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
