### PR TITLE
Fix IndexError in URL.replace() when netloc is empty

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -125,7 +125,7 @@ class URL:
                 netloc = self.netloc
                 _, _, hostname = netloc.rpartition("@")
 
-                if hostname[-1] != "]":
+                if hostname and hostname[-1] != "]":
                     hostname = hostname.rsplit(":", 1)[0]
 
             netloc = hostname


### PR DESCRIPTION
## Summary

`URL.replace()` raises an `IndexError` when called with `username`, `password`, or `port` arguments on a URL that has no network location (e.g. a relative path or empty URL).

## Reproduction

```python
from starlette.datastructures import URL

url = URL("/some/path")
url.replace(username="user")  # IndexError: string index out of range
```

## Cause

When `hostname` is not provided in the kwargs, the code tries to extract it from the current `netloc`. If the netloc is empty (as it is for path-only URLs), `rpartition("@")` returns an empty string for hostname, and the subsequent `hostname[-1]` indexing raises `IndexError`.

## Fix

Added a truthiness check (`if hostname and hostname[-1] != "]"`) to guard against indexing into an empty string.
