### PR TITLE
Add __contains__, __eq__, and __repr__ to State

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -704,3 +704,15 @@ class State:
 
     def __len__(self) -> int:
         return len(self._state)
+
+    def __contains__(self, key: Any) -> bool:
+        return key in self._state
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, State):
+            return NotImplemented
+        return self._state == other._state
+
+    def __repr__(self) -> str:
+        contents = ", ".join(f"{k}={v!r}" for k, v in self._state.items())
+        return f"{self.__class__.__name__}({contents})"


### PR DESCRIPTION
## Summary

The `State` class (used for `request.state` and `app.state`) was missing a few commonly expected dunder methods, making it harder to work with in tests and during debugging.

## Changes

Added three methods to `State`:

### `__contains__`

Without this, `"key" in state` falls back to `__iter__`, which iterates over all keys in O(n) time. With an explicit `__contains__`, the lookup delegates to the underlying dict in O(1).

```python
state = State()
state.counter = 0
"counter" in state  # True, O(1or)
```

### `__eq__`

Allows direct comparison of `State` objects, which is particularly useful in tests. Returns `NotImplemented` for non-State comparisons so Python can try the other operand's `__eq__`.

```python
state1 = State({"a": 1})
state2 = State({"a": 1})
assert state1 == state2
```

### `__repr__`

Provides a readable representation instead of the default `<State object at 0x...>`, making debugging significantly easier.

```python
state = State()
state.debug = True
state.counter = 42
repr(state)  # "State(debug=True, counter=42)"
```
