### PR TITLE
Use light logo as `<img>` fallback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Kludex/starlette/main/docs/img/starlette_dark.svg" width="420px">
     <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Kludex/starlette/main/docs/img/starlette.svg" width="420px">
-    <img alt="starlette-logo" src="https://raw.githubusercontent.com/Kludex/starlette/main/docs/img/starlette_dark.svg">
+    <img alt="starlette-logo" src="https://raw.githubusercontent.com/Kludex/starlette/main/docs/img/starlette.svg">
   </picture>
 </p>
 


### PR DESCRIPTION
PyPI doesn't support `<picture>`, so it renders the `<img>` fallback. The dark variant (white text on transparent) is invisible on PyPI's white background. Switch the fallback to the light variant.
