### PR TITLE
feat: add Request.read(size) method for partial body reading

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -669,3 +669,26 @@ def test_request_url_starlette_context(test_client_factory: TestClientFactory) -
     client = test_client_factory(app)
     client.get("/home")
     assert url_for == URL("http://testserver/home")
+
+def test_request_read_n_bytes(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+
+        chunk1 = await request.read(5)
+        chunk2 = await request.read(5)
+        chunk3 = await request.read(5)  # less than 5 bytes remain
+
+        response = JSONResponse({
+            "chunk1": chunk1.decode(),
+            "chunk2": chunk2.decode(),
+            "chunk3": chunk3.decode(),
+        })
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.post("/", content=b"HELLO WORLD!!!")
+    assert response.json() == {
+        "chunk1": "HELLO",
+        "chunk2": " WORL",
+        "chunk3": "D!!!",
+    }


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Adds a `read(size)` method to the `Request` class that reads exactly `size` bytes from the request body at a time. Currently there is no way to read a specific number of bytes from the request body. The only options are `body()` which loads everything into memory at once, or `stream()` which gives server-decided chunk sizes.
This is useful for processing large request bodies in chunks without loading everything into memory — for example, saving portions of a large body to multiple files.

Relates to #3113 
Example usage:
chunk1 = await request.read(1024)  # first 1KB
chunk2 = await request.read(1024)  # next 1KB
chunk3 = await request.read(-1)    # rest of body

# Checklist
- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
