### PR TITLE
Track session access and modification in `SessionMiddleware`

### DIFF
--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import typing
 from base64 import b64decode, b64encode
 from typing import Literal
 
@@ -47,20 +48,23 @@ class SessionMiddleware:
             data = connection.cookies[self.session_cookie].encode("utf-8")
             try:
                 data = self.signer.unsign(data, max_age=self.max_age)
-                scope["session"] = json.loads(b64decode(data))
+                scope["session"] = Session(json.loads(b64decode(data)))
                 initial_session_was_empty = False
             except BadSignature:
-                scope["session"] = {}
+                scope["session"] = Session()
         else:
-            scope["session"] = {}
+            scope["session"] = Session()
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
-                if scope["session"]:
+                session: Session = scope["session"]
+                headers = MutableHeaders(scope=message)
+                if session.accessed:
+                    headers.add_vary_header("Cookie")
+                if session.modified and session:
                     # We have session data to persist.
-                    data = b64encode(json.dumps(scope["session"]).encode("utf-8"))
+                    data = b64encode(json.dumps(session).encode("utf-8"))
                     data = self.signer.sign(data)
-                    headers = MutableHeaders(scope=message)
                     header_value = "{session_cookie}={data}; path={path}; {max_age}{security_flags}".format(
                         session_cookie=self.session_cookie,
                         data=data.decode("utf-8"),
@@ -69,9 +73,8 @@ class SessionMiddleware:
                         security_flags=self.security_flags,
                     )
                     headers.append("Set-Cookie", header_value)
-                elif not initial_session_was_empty:
+                elif session.modified and not initial_session_was_empty:
                     # The session has been cleared.
-                    headers = MutableHeaders(scope=message)
                     header_value = "{session_cookie}={data}; path={path}; {expires}{security_flags}".format(
                         session_cookie=self.session_cookie,
                         data="null",
@@ -83,3 +86,76 @@ class SessionMiddleware:
             await send(message)
 
         await self.app(scope, receive, send_wrapper)
+
+
+class Session(dict[str, typing.Any]):
+    accessed: bool = False
+    modified: bool = False
+
+    def _mark_accessed(self) -> None:
+        self.accessed = True
+
+    def _mark_modified(self) -> None:
+        self.accessed = True
+        self.modified = True
+
+    def __getitem__(self, key: str) -> typing.Any:
+        self._mark_accessed()
+        return super().__getitem__(key)
+
+    def get(self, key: str, default: typing.Any = None) -> typing.Any:
+        self._mark_accessed()
+        return super().get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        self._mark_accessed()
+        return super().__contains__(key)
+
+    def __iter__(self) -> typing.Iterator[str]:
+        self._mark_accessed()
+        return super().__iter__()
+
+    def __len__(self) -> int:
+        self._mark_accessed()
+        return super().__len__()
+
+    def __bool__(self) -> bool:
+        self._mark_accessed()
+        return super().__len__() > 0
+
+    def keys(self) -> typing.KeysView[str]:
+        self._mark_accessed()
+        return super().keys()
+
+    def values(self) -> typing.ValuesView[typing.Any]:
+        self._mark_accessed()
+        return super().values()
+
+    def items(self) -> typing.ItemsView[str, typing.Any]:
+        self._mark_accessed()
+        return super().items()
+
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        self._mark_modified()
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        self._mark_modified()
+        super().__delitem__(key)
+
+    def clear(self) -> None:
+        self._mark_modified()
+        super().clear()
+
+    def pop(self, key: str, *args: typing.Any) -> typing.Any:
+        self.modified = self.modified or key in self  # `in` sets accessed
+        return super().pop(key, *args)
+
+    def setdefault(self, key: str, default: typing.Any = None) -> typing.Any:
+        if key not in self:
+            self._mark_modified()
+        return super().setdefault(key, default)
+
+    def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self._mark_modified()
+        super().update(*args, **kwargs)

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import json
 import typing
 from base64 import b64decode, b64encode
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import itsdangerous
 from itsdangerous.exc import BadSignature
+
+if TYPE_CHECKING:
+    from builtins import dict_items, dict_keys, dict_values  # type: ignore[attr-defined]
 
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import HTTPConnection
@@ -123,15 +126,15 @@ class Session(dict[str, typing.Any]):
         self._mark_accessed()
         return super().__len__() > 0
 
-    def keys(self) -> typing.KeysView[str]:
+    def keys(self) -> dict_keys[str, typing.Any]:
         self._mark_accessed()
         return super().keys()
 
-    def values(self) -> typing.ValuesView[typing.Any]:
+    def values(self) -> dict_values[str, typing.Any]:
         self._mark_accessed()
         return super().values()
 
-    def items(self) -> typing.ItemsView[str, typing.Any]:
+    def items(self) -> dict_items[str, typing.Any]:
         self._mark_accessed()
         return super().items()
 

--- a/starlette/middleware/sessions.py
+++ b/starlette/middleware/sessions.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import json
 import typing
 from base64 import b64decode, b64encode
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import itsdangerous
 from itsdangerous.exc import BadSignature
-
-if TYPE_CHECKING:
-    from builtins import dict_items, dict_keys, dict_values  # type: ignore[attr-defined]
 
 from starlette.datastructures import MutableHeaders, Secret
 from starlette.requests import HTTPConnection
@@ -95,70 +92,34 @@ class Session(dict[str, typing.Any]):
     accessed: bool = False
     modified: bool = False
 
-    def _mark_accessed(self) -> None:
+    def mark_accessed(self) -> None:
         self.accessed = True
 
-    def _mark_modified(self) -> None:
+    def mark_modified(self) -> None:
         self.accessed = True
         self.modified = True
 
-    def __getitem__(self, key: str) -> typing.Any:
-        self._mark_accessed()
-        return super().__getitem__(key)
-
-    def get(self, key: str, default: typing.Any = None) -> typing.Any:
-        self._mark_accessed()
-        return super().get(key, default)
-
-    def __contains__(self, key: object) -> bool:
-        self._mark_accessed()
-        return super().__contains__(key)
-
-    def __iter__(self) -> typing.Iterator[str]:
-        self._mark_accessed()
-        return super().__iter__()
-
-    def __len__(self) -> int:
-        self._mark_accessed()
-        return super().__len__()
-
-    def __bool__(self) -> bool:
-        self._mark_accessed()
-        return super().__len__() > 0
-
-    def keys(self) -> dict_keys[str, typing.Any]:
-        self._mark_accessed()
-        return super().keys()
-
-    def values(self) -> dict_values[str, typing.Any]:
-        self._mark_accessed()
-        return super().values()
-
-    def items(self) -> dict_items[str, typing.Any]:
-        self._mark_accessed()
-        return super().items()
-
     def __setitem__(self, key: str, value: typing.Any) -> None:
-        self._mark_modified()
+        self.mark_modified()
         super().__setitem__(key, value)
 
     def __delitem__(self, key: str) -> None:
-        self._mark_modified()
+        self.mark_modified()
         super().__delitem__(key)
 
     def clear(self) -> None:
-        self._mark_modified()
+        self.mark_modified()
         super().clear()
 
     def pop(self, key: str, *args: typing.Any) -> typing.Any:
-        self.modified = self.modified or key in self  # `in` sets accessed
+        self.modified = self.modified or key in self
         return super().pop(key, *args)
 
     def setdefault(self, key: str, default: typing.Any = None) -> typing.Any:
         if key not in self:
-            self._mark_modified()
+            self.mark_modified()
         return super().setdefault(key, default)
 
     def update(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        self._mark_modified()
+        self.mark_modified()
         super().update(*args, **kwargs)

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from python_multipart.multipart import parse_options_header
 
     from starlette.applications import Starlette
+    from starlette.middleware.sessions import Session
     from starlette.routing import Router
 else:
     try:
@@ -167,7 +168,11 @@ class HTTPConnection(Mapping[str, Any], Generic[StateT]):
     @property
     def session(self) -> dict[str, Any]:
         assert "session" in self.scope, "SessionMiddleware must be installed to access request.session"
-        return self.scope["session"]  # type: ignore[no-any-return]
+        session: Session = self.scope["session"]
+        # We keep the hasattr in case people actually use their own `SessionMiddleware` implementation.
+        if hasattr(session, "mark_accessed"):  # pragma: no branch
+            session.mark_accessed()
+        return session
 
     @property
     def auth(self) -> Any:


### PR DESCRIPTION
## Summary

`SessionMiddleware` currently sends `Set-Cookie` on every response when the session is non-empty, even if nothing changed. This causes race conditions with concurrent requests - a slow read-only response can clobber a newer session cookie (see #2019, [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=696204#c107), [authlib#334](https://github.com/lepture/authlib/issues/334)).

This PR replaces the plain `dict` used for `scope["session"]` with a `Session` subclass that tracks two flags:

- **`accessed`**: set in `HTTPConnection.session` when the session is accessed, following [Flask 3.1.3's approach](https://github.com/pallets/flask/blob/main/src/flask/ctx.py) of tracking at the property level rather than per-method overrides
- **`modified`**: set on write operations (`__setitem__`, `__delitem__`, `clear`, `update`), with `pop` and `setdefault` conditionally marking modified only when the session actually changes (following [Django](https://github.com/django/django/blob/main/django/contrib/sessions/backends/base.py) and [Flask/Werkzeug](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/datastructures/structures.py) conventions)

The middleware then uses these flags to:

- Only send `Set-Cookie` when `modified` is `True`
- Add `Vary: Cookie` when `accessed` is `True`, so reverse proxies and CDNs don't cache session-dependent responses incorrectly

---

- Closes #2019
- Replaces #2527, which addresses the same `modified` tracking but bundles unrelated features (`partitioned` cookies, `refresh_window`). This PR scopes the change to just access/modification tracking.