### PR TITLE
Replace RuntimeError with WebSocketDisconnect when socket is disconnected

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -32,6 +32,13 @@ class WebSocket(HTTPConnection[StateT]):
         self.client_state = WebSocketState.CONNECTING
         self.application_state = WebSocketState.CONNECTING
 
+    @property
+    def is_disconnected(self) -> bool:
+        return (
+            self.client_state == WebSocketState.DISCONNECTED
+            or self.application_state == WebSocketState.DISCONNECTED
+        )
+
     async def receive(self) -> Message:
         """
         Receive ASGI websocket messages, ensuring valid state transitions.
@@ -54,7 +61,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.client_state = WebSocketState.DISCONNECTED
             return message
         else:
-            raise RuntimeError('Cannot call "receive" once a disconnect message has been received.')
+            raise WebSocketDisconnect(code=1000)
 
     async def send(self, message: Message) -> None:
         """
@@ -95,7 +102,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect(code=1000)
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 
@@ -502,9 +502,37 @@ def test_duplicate_disconnect(test_client_factory: TestClientFactory) -> None:
         message = await websocket.receive()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/") as websocket:
             websocket.close()
+
+
+def test_websocket_is_disconnected(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        assert not websocket.is_disconnected
+        await websocket.accept()
+        assert not websocket.is_disconnected
+        message = await websocket.receive()
+        assert message["type"] == "websocket.disconnect"
+        assert websocket.is_disconnected
+
+    client = test_client_factory(app)
+    with client.websocket_connect("/") as websocket:
+        websocket.close()
+
+
+def test_websocket_is_disconnected_on_close(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        websocket = WebSocket(scope, receive=receive, send=send)
+        await websocket.accept()
+        assert not websocket.is_disconnected
+        await websocket.close()
+        assert websocket.is_disconnected
+
+    client = test_client_factory(app)
+    with client.websocket_connect("/"):
+        pass
 
 
 def test_websocket_scope_interface() -> None:


### PR DESCRIPTION
Closes #2766

## Changes
- Replace `RuntimeError` with `WebSocketDisconnect` in `WebSocket.receive()` when called after disconnect message has been received
- Replace `RuntimeError` with `WebSocketDisconnect` in `WebSocket.send()` when called after close message has been sent  
- Add `is_disconnected` property to `WebSocket` for checking connection state (as discussed in [#2762](https://github.com/encode/starlette/discussions/2762))
- Update tests to expect `WebSocketDisconnect` instead of `RuntimeError`
- Add tests for `is_disconnected` property

## Motivation
When handling WebSocket connections in concurrent scenarios (e.g., multiple coroutines managing the same connection), it's common for one coroutine to close the connection while another attempts to send/receive. Currently this raises a generic `RuntimeError`, but `WebSocketDisconnect` is more semantically appropriate and allows users to catch a single exception type.

## Testing
- All 290 relevant tests pass (websocket, routing, applications, endpoints, testclient)
- Added 2 new tests for `is_disconnected` property
