### PR TITLE
Clear exc.__traceback__ after handled exceptions to prevent memory leak

### DIFF
--- a/starlette/_exception_handler.py
+++ b/starlette/_exception_handler.py
@@ -61,5 +61,11 @@ def wrap_app_handling_exceptions(app: ASGIApp, conn: Request | WebSocket) -> ASG
                 response = await run_in_threadpool(handler, conn, exc)
             if response is not None:
                 await response(scope, receive, sender)
+            # Clear the traceback to break the reference cycle:
+            # exc.__traceback__ → frame locals → sender closure → send
+            # → RequestResponseCycle. Without this, shared exception
+            # objects (e.g. module-level HTTPException instances) pin
+            # per-request ASGI state in memory permanently.
+            exc.__traceback__ = None
 
     return wrapped_app

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -222,3 +222,22 @@ def test_handlers_annotations() -> None:
 
     ExceptionMiddleware(router, handlers={Exception: sync_catch_all_handler})
     ExceptionMiddleware(router, handlers={Exception: async_catch_all_handler})
+
+
+def test_handled_exception_clears_traceback(test_client_factory: TestClientFactory) -> None:
+    """Shared exception objects must not retain __traceback__ after handling.
+
+    If __traceback__ is not cleared, the traceback frame keeps a reference to
+    the ASGI send closure and its locals, pinning per-request state in memory
+    for the lifetime of the exception object.
+    """
+    shared_exc = HTTPException(status_code=401, detail="Unauthorized")
+
+    async def raise_shared_exc(request: Request) -> None:
+        raise shared_exc
+
+    app = ExceptionMiddleware(Router(routes=[Route("/", endpoint=raise_shared_exc)]))
+    client = test_client_factory(app, raise_server_exceptions=False)
+    response = client.get("/")
+    assert response.status_code == 401
+    assert shared_exc.__traceback__ is None


### PR DESCRIPTION
## Summary

- When `wrap_app_handling_exceptions` catches and successfully handles an exception, `exc.__traceback__` retains a reference to the frame's locals, which include the ASGI `send`/`receive` closures and per-request state
- If the exception object is long-lived (e.g., a module-level `HTTPException` reused across requests — common in auth libraries), this pins per-request objects in memory permanently. GC cannot collect these because the module holds a strong non-cyclic reference to the exception
- The fix adds `exc.__traceback__ = None` after the handler runs and the response is sent. Unhandled exceptions (`raise exc`) are not affected — their traceback is preserved for propagation

### Reference chain that causes the leak

```
exception.__traceback__
  → frame (wrapped_app's except block)
    → locals:
      → sender (closure) → captured `send` → RequestResponseCycle (~19 KB)
      → receive → RequestResponseCycle
```

### Precedent

- **[CPython #88863](https://github.com/python/cpython/issues/88863)** — same bug class in `asyncio.open_connection`. Fixed by clearing references after exception handling. Backported to 3.10/3.11.
- **Uvicorn PR #1604** — fixed a related cyclic reference leak by nulling `self.parser` after connection loss.

## Test plan

- [x] Reproduced the bug on unpatched code (shared exception's `__traceback__` is not `None` after handling)
- [x] Confirmed the fix resolves it (`__traceback__` is `None` after handling)
- [x] Verified traceback doesn't accumulate across 100 requests
- [x] Verified unhandled exceptions (no handler found → `raise exc`) still preserve their traceback
- [x] New test `test_handled_exception_clears_traceback` passes on both asyncio and trio
- [x] Full test suite: 925 passed, 2 xfailed, 0 failures