### PR TITLE
Fix GZipMiddleware buffering streaming response chunks

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -133,6 +133,13 @@ class GZipResponder(IdentityResponder):
         self.gzip_file.write(body)
         if not more_body:
             self.gzip_file.close()
+        else:
+            # Flush the compressor to emit all pending compressed bytes.
+            # Without this, zlib buffers output internally and clients
+            # receive data in large irregular bursts instead of progressively.
+            # GzipFile.flush() issues a Z_SYNC_FLUSH (RFC 1951 §3.2.3),
+            # which appends a sync point that all standard decompressors handle.
+            self.gzip_file.flush()
 
         body = self.gzip_buffer.getvalue()
         self.gzip_buffer.seek(0)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -93,6 +93,21 @@ def test_gzip_streaming_response(test_client_factory: TestClientFactory) -> None
     assert "Content-Length" not in response.headers
 
 
+def test_gzip_streaming_response_flushes_every_chunk() -> None:
+    """Without flushing, zlib buffers output internally and clients receive
+    data in large irregular bursts instead of progressively (Z_SYNC_FLUSH, RFC 1951)."""
+    from starlette.middleware.gzip import GZipResponder
+
+    responder = GZipResponder(app=None, minimum_size=500)  # type: ignore[arg-type]
+
+    for i in range(10):
+        body = responder.apply_compression(b"x" * 4000, more_body=True)
+        assert len(body) > 0, f"Chunk {i} produced 0 bytes"
+
+    final = responder.apply_compression(b"x" * 4000, more_body=False)
+    assert len(final) > 0
+
+
 def test_gzip_streaming_response_identity(test_client_factory: TestClientFactory) -> None:
     def homepage(request: Request) -> StreamingResponse:
         async def generator(bytes: bytes, count: int) -> ContentStream:


### PR DESCRIPTION
# Summary
GZipResponder.apply_compression() never called gzip_file.flush() for intermediate streaming chunks (more_body=True), causing zlib to hold compressed bytes in its internal buffer until ~32KB accumulated or the stream closed. Added self.gzip_file.flush() (Z_SYNC_FLUSH) so compressed bytes are emitted immediately for each chunk.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
