### PR TITLE
docs: fix grammar in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,7 +109,7 @@ Here are some common ways the test suite can fail:
 </p>
 
 This job failing means there is either a code formatting issue or type-annotation issue.
-You can look at the job output to figure out why it's failed or within a shell run:
+You can look at the job output to figure out why it failed or within a shell run:
 
 ```shell
 $ scripts/check
@@ -165,4 +165,3 @@ Once the release PR is merged, create a
 - Description copied from the changelog.
 
 Once created this release will be automatically uploaded to PyPI.
-

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,7 +109,7 @@ Here are some common ways the test suite can fail:
 </p>
 
 This job failing means there is either a code formatting issue or type-annotation issue.
-You can look at the job output to figure out why it failed or within a shell run:
+You can look at the job output to figure out why it failed, or run the following within a shell:
 
 ```shell
 $ scripts/check


### PR DESCRIPTION
# Summary
Fixes a small grammar issue in the contributing guide by changing `why it's failed` to `why it failed`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (N/A: docs-only)
- [x] I've updated the documentation accordingly.
