### PR TITLE
Add strict JSON Content-Type validation

### DIFF
--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -258,8 +258,22 @@ class Request(HTTPConnection[StateT]):
             self._body = b"".join(chunks)
         return self._body
 
-    async def json(self) -> Any:
+    async def json(self, *, strict: bool = False) -> Any:
         if not hasattr(self, "_json"):  # pragma: no branch
+            if strict:
+                content_type_header = self.headers.get("Content-Type", "")
+                content_type = content_type_header.split(";", 1)[0].strip().lower()
+
+                if "/" not in content_type:
+                    is_json = False
+                else:
+                    base_type, subtype = content_type.split("/")
+                    is_json = base_type == "application" and (subtype == "json" or subtype.endswith("+json"))
+
+                if not is_json:
+                    raise RuntimeError(
+                        f"Invalid content type. Expected 'application/json', got {content_type_header!r}."
+                    )
             body = await self.body()
             self._json = json.loads(body)
         return self._json

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -192,6 +192,47 @@ def test_request_json(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"json": {"a": "123"}}
 
 
+def test_request_json_strict_invalid_content_type(test_client_factory: TestClientFactory) -> None:
+    """
+    Test request's content-type is not application/json and strict mode is enabled
+    """
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        data = await request.json(strict=True)
+        response = JSONResponse({"json": data})
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    with pytest.raises(RuntimeError):
+        client.post("/", json={"a": "123"}, headers={"Content-Type": "text/plain; charset=utf-8"})
+
+
+def test_request_json_strict_valid_content_type(test_client_factory: TestClientFactory) -> None:
+    """
+    Test request's content-type is application/json and strict mode is enabled
+    """
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        request = Request(scope, receive)
+        data = await request.json(strict=True)
+        response = JSONResponse({"json": data})
+        await response(scope, receive, send)
+
+    payload = {"a": "123"}
+
+    client = test_client_factory(app)
+    # default
+    response = client.post("/", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"json": payload}
+
+    # edge case
+    response = client.post("/", json=payload, headers={"Content-Type": " application/json ; charset=utf-8 "})
+    assert response.status_code == 200
+    assert response.json() == {"json": payload}
+
+
 def test_request_scope_interface() -> None:
     """
     A Request can be instantiated with a scope, and presents a `Mapping`

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -199,10 +199,8 @@ def test_request_json_strict_invalid_content_type(test_client_factory: TestClien
 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
-        data = await request.json(strict=True)
-        response = JSONResponse({"json": data})
-        await response(scope, receive, send)
-
+        await request.json(strict=True)
+        
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
         client.post("/", json={"a": "123"}, headers={"Content-Type": "text/plain; charset=utf-8"})

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -192,7 +192,8 @@ def test_request_json(test_client_factory: TestClientFactory) -> None:
     assert response.json() == {"json": {"a": "123"}}
 
 
-def test_request_json_strict_invalid_content_type(test_client_factory: TestClientFactory) -> None:
+@pytest.mark.parametrize("content_type", ["text/plain; charset=utf-8", "applicationjson"])
+def test_request_json_strict_invalid_content_type(content_type: str, test_client_factory: TestClientFactory) -> None:
     """
     Test request's content-type is not application/json and strict mode is enabled
     """
@@ -200,10 +201,10 @@ def test_request_json_strict_invalid_content_type(test_client_factory: TestClien
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         request = Request(scope, receive)
         await request.json(strict=True)
-        
+
     client = test_client_factory(app)
     with pytest.raises(RuntimeError):
-        client.post("/", json={"a": "123"}, headers={"Content-Type": "text/plain; charset=utf-8"})
+        client.post("/", json={"a": "123"}, headers={"Content-Type": content_type})
 
 
 def test_request_json_strict_valid_content_type(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
# Summary

Introduces a `strict` parameter for `Request.json()` that validates the request's
`Content-Type` before parsing.

When `strict=True`, a `RuntimeError` is raised if the `Content-Type` is
not `application/json` or does not match `application/*+json`.

This makes JSON parsing consistent with `Request.form()` which also checks
the `Content-Type` header.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
