### PR TITLE
fix(cors): raise ValueError when allow_credentials=True with allow_origins=["*"]

### DIFF
--- a/starlette/middleware/cors.py
+++ b/starlette/middleware/cors.py
@@ -25,6 +25,14 @@ class CORSMiddleware:
         expose_headers: Sequence[str] = (),
         max_age: int = 600,
     ) -> None:
+        if allow_credentials and "*" in allow_origins:
+            raise ValueError(
+                'CORSMiddleware: allow_credentials=True may not be used with allow_origins=["*"]. '
+                "Allowing credentials from every origin is a security misconfiguration — any website "
+                "can make authenticated cross-origin requests on behalf of your users. "
+                "Specify explicit trusted origins in allow_origins instead."
+            )
+
         if "*" in allow_methods:
             allow_methods = ALL_METHODS
 


### PR DESCRIPTION
## Summary

When `CORSMiddleware` is configured with both `allow_origins=["*"]` and `allow_credentials=True`, the middleware silently echoes back any requesting `Origin` with `Access-Control-Allow-Credentials: true`. This effectively grants every website the ability to make authenticated cross-origin requests on behalf of your users — a serious security misconfiguration.

The W3C CORS spec explicitly prohibits this combination: credentials cannot be used with the wildcard origin. Browsers already block responses with `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Credentials: true`, which is why starlette echoes the origin back instead. This makes the real behaviour less obvious and the security risk easy to overlook.

This PR adds an early `ValueError` in `__init__` so the misconfiguration is caught at startup rather than silently allowed at runtime.

## Changes

- `starlette/middleware/cors.py`: add guard in `CORSMiddleware.__init__` that raises `ValueError` if `allow_credentials=True` and `"*"` is in `allow_origins`

## Test plan

- [ ] Existing CORS test suite passes
- [ ] `CORSMiddleware(app, allow_origins=["*"], allow_credentials=True)` now raises `ValueError` at instantiation
- [ ] `CORSMiddleware(app, allow_origins=["https://example.com"], allow_credentials=True)` continues to work

Some code in this commit was written with assistance from Claude Sonnet 4.6 (AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)