### PR TITLE
Optional Cache-Control header support to Staticfile responses

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -3,13 +3,14 @@ Starlette also includes a `StaticFiles` class for serving files in a given direc
 
 ### StaticFiles
 
-Signature: `StaticFiles(directory=None, packages=None, html=False, check_dir=True, follow_symlink=False)`
+Signature: `StaticFiles(directory=None, packages=None, html=False, check_dir=True, follow_symlink=False, cache_control=None)`
 
 * `directory` - A string or [os.PathLike][pathlike] denoting a directory path.
 * `packages` - A list of strings or list of tuples of strings of python packages.
 * `html` - Run in HTML mode. Automatically loads `index.html` for directories if such file exist.
 * `check_dir` - Ensure that the directory exists upon instantiation. Defaults to `True`.
 * `follow_symlink` - A boolean indicating if symbolic links for files and directories should be followed. Defaults to `False`.
+* `cache_control` - A string to set the default `Cache-Control` for all static file responses.
 
 You can combine this ASGI application with Starlette's routing to provide
 comprehensive static file serving.

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -45,6 +45,7 @@ class StaticFiles:
         html: bool = False,
         check_dir: bool = True,
         follow_symlink: bool = False,
+        cache_control: str | None = None,
     ) -> None:
         self.directory = directory
         self.packages = packages
@@ -52,6 +53,7 @@ class StaticFiles:
         self.html = html
         self.config_checked = False
         self.follow_symlink = follow_symlink
+        self.cache_control = cache_control
         if check_dir and directory is not None and not os.path.isdir(directory):
             raise RuntimeError(f"Directory '{directory}' does not exist")
 
@@ -129,7 +131,10 @@ class StaticFiles:
 
         if stat_result and stat.S_ISREG(stat_result.st_mode):
             # We have a static file to serve.
-            return self.file_response(full_path, stat_result, scope)
+            file_response = self.file_response(full_path, stat_result, scope)
+            if self.cache_control:
+                file_response.headers["Cache-Control"] = self.cache_control
+            return file_response
 
         elif stat_result and stat.S_ISDIR(stat_result.st_mode) and self.html:
             # We're in HTML mode, and have got a directory URL.

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -629,11 +629,12 @@ def test_staticfiles_relative_directory_symlinks(test_client_factory: TestClient
     assert response.status_code == 200
     assert response.text == "123\n"
 
+
 def test_static_files_cache_control(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     cache_control = "public, max-age=604800"
     path = tmp_path / "example.txt"
     path.write_text("<file content>")
-    
+
     app = StaticFiles(directory=tmp_path, cache_control=cache_control)
     client = test_client_factory(app)
     response = client.get("/example.txt")

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -628,3 +628,14 @@ def test_staticfiles_relative_directory_symlinks(test_client_factory: TestClient
     response = client.get("/example.txt")
     assert response.status_code == 200
     assert response.text == "123\n"
+
+def test_static_files_cache_control(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    cache_control = "public, max-age=604800"
+    path = tmp_path / "example.txt"
+    path.write_text("<file content>")
+    
+    app = StaticFiles(directory=tmp_path, cache_control=cache_control)
+    client = test_client_factory(app)
+    response = client.get("/example.txt")
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == cache_control


### PR DESCRIPTION
# Summary
This adds an optional `cache_control` parameter to `StaticFiles`, allowing developers to set a default
`Cache-Control` header for all static file responses.

#### This does not change the default behavior when the parameter is not provided.

### Why this makes sense

Providing a simple way to configure a default `Cache-Control` header for static files simplifies common
deployment scenarios.

Many small services rely on a basic cache policy for static assets. This change allows that behavior
to be configured directly without requiring additional middleware or custom wrappers.
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
