### PR TITLE
docs: link to ASGI server implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It is production-ready, and gives you the following:
 $ pip install starlette
 ```
 
-You'll also want to install an ASGI server, such as [uvicorn](https://www.uvicorn.org/), [daphne](https://github.com/django/daphne/), or [hypercorn](https://hypercorn.readthedocs.io/en/latest/).
+You'll also want to install an ASGI server; see the [ASGI server implementations list](https://asgi.readthedocs.io/en/latest/implementations.html#servers).
 
 ```shell
 $ pip install uvicorn

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ Help us keep Starlette maintained and sustainable by [becoming a sponsor](https:
 pip install starlette
 ```
 
-You'll also want to install an ASGI server, such as [uvicorn](https://www.uvicorn.org/), [daphne](https://github.com/django/daphne/), or [hypercorn](https://hypercorn.readthedocs.io/en/latest/).
+You'll also want to install an ASGI server; see the [ASGI server implementations list](https://asgi.readthedocs.io/en/latest/implementations.html#servers).
 
 ```shell
 pip install uvicorn


### PR DESCRIPTION
# Summary

Replaces the inline ASGI server list in the installation docs with a link to the canonical ASGI implementations page.

Closes #3203.

# Details

- Updated `README.md` and `docs/index.md` to point to:
  https://asgi.readthedocs.io/en/latest/implementations.html#servers
- Rationale: the inline list can go stale/incomplete; the ASGI spec maintains the up-to-date server list.

# Testing

- `python -m pytest -q`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (Issue #3203 requested this change.)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. (Docs-only change; no tests added.)
- [x] I've updated the documentation accordingly.