### PR TITLE
Fix static file conditional requests and ranges

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -445,7 +445,6 @@ class FileResponse(Response):
 
     @staticmethod
     def _parse_range_header(http_range: str, file_size: int) -> list[tuple[int, int]]:
-        ranges: list[tuple[int, int]] = []
         try:
             units, range_ = http_range.split("=", 1)
         except ValueError:
@@ -456,14 +455,27 @@ class FileResponse(Response):
         if units != "bytes":
             raise MalformedRangeHeader("Only support bytes range")
 
-        ranges = [
-            (
-                int(_[0]) if _[0] else file_size - int(_[1]),
-                int(_[1]) + 1 if _[0] and _[1] and int(_[1]) < file_size else file_size,
-            )
-            for _ in _RANGE_PATTERN.findall(range_)
-            if _ != ("", "")
-        ]
+        ranges: list[tuple[int, int]] = []
+        for range_part in range_.split(","):
+            range_part = range_part.strip()
+            if not range_part:
+                continue
+
+            match = _RANGE_PATTERN.fullmatch(range_part)
+            if match is None:
+                raise MalformedRangeHeader()
+
+            start_str, end_str = match.groups()
+            if start_str == end_str == "":
+                continue
+
+            if start_str:
+                start = int(start_str)
+                end = int(end_str) + 1 if end_str else file_size
+                ranges.append((start, min(end, file_size)))
+            else:
+                suffix_length = int(end_str)
+                ranges.append((max(file_size - suffix_length, 0), file_size))
 
         if len(ranges) == 0:
             raise MalformedRangeHeader("Range header: range must be requested")
@@ -471,7 +483,7 @@ class FileResponse(Response):
         if any(not (0 <= start < file_size) for start, _ in ranges):
             raise RangeNotSatisfiable(file_size)
 
-        if any(start > end for start, end in ranges):
+        if any(start >= end for start, end in ranges):
             raise MalformedRangeHeader("Range header: start must be less than end")
 
         if len(ranges) == 1:

--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -203,11 +203,15 @@ class StaticFiles:
         """
         try:
             if_none_match = request_headers["if-none-match"]
-            etag = response_headers["etag"]
-            if etag in [tag.strip(" W/") for tag in if_none_match.split(",")]:
-                return True
         except KeyError:
             pass
+        else:
+            # RFC 9110: If-None-Match takes precedence over If-Modified-Since.
+            try:
+                etag = response_headers["etag"]
+            except KeyError:
+                return False
+            return self._etag_matches(etag, if_none_match)
 
         try:
             if_modified_since = parsedate(request_headers["if-modified-since"])
@@ -218,3 +222,12 @@ class StaticFiles:
             pass
 
         return False
+
+    @staticmethod
+    def _etag_matches(etag: str, if_none_match: str) -> bool:
+        def normalize(tag: str) -> str:
+            tag = tag.strip()
+            return tag[2:] if tag.startswith("W/") else tag
+
+        normalized_etag = normalize(etag)
+        return any(tag.strip() == "*" or normalize(tag) == normalized_etag for tag in if_none_match.split(","))

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -715,6 +715,26 @@ def test_file_response_start_must_be_less_than_end(file_response_client: TestCli
     assert response.text == "Range header: start must be less than end"
 
 
+@pytest.mark.parametrize("range_header", ["bytes=abc0-10", "bytes=0-10x", "bytes=0-10, junk"])
+def test_file_response_range_malformed_with_extra_text(
+    file_response_client: TestClient, range_header: str
+) -> None:
+    response = file_response_client.get("/", headers={"Range": range_header})
+    assert response.status_code == 400
+    assert response.text == "Malformed range header."
+
+
+def test_file_response_range_suffix_larger_than_file(file_response_client: TestClient) -> None:
+    file_size = len(README.encode("utf8"))
+
+    response = file_response_client.get("/", headers={"Range": f"bytes=-{file_size + 1}"})
+
+    assert response.status_code == 206
+    assert response.headers["content-range"] == f"bytes 0-{file_size - 1}/{file_size}"
+    assert response.headers["content-length"] == str(file_size)
+    assert response.text == README
+
+
 def test_file_response_merge_ranges(file_response_client: TestClient) -> None:
     response = file_response_client.get("/", headers={"Range": "bytes=0-100, 50-200"})
     assert response.status_code == 206

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -216,6 +216,18 @@ def test_staticfiles_304_with_etag_match(tmpdir: Path, test_client_factory: Test
     assert second_resp.content == b""
 
 
+def test_staticfiles_304_with_if_none_match_wildcard(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
+    path = os.path.join(tmpdir, "example.txt")
+    with open(path, "w") as file:
+        file.write("<file content>")
+
+    app = StaticFiles(directory=tmpdir)
+    client = test_client_factory(app)
+    response = client.get("/example.txt", headers={"if-none-match": "*"})
+    assert response.status_code == 304
+    assert response.content == b""
+
+
 def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: TestClientFactory) -> None:
     path = os.path.join(tmpdir, "example.txt")
     with open(path, "w") as file:
@@ -229,6 +241,28 @@ def test_staticfiles_200_with_etag_mismatch(tmpdir: Path, test_client_factory: T
     second_resp = client.get("/example.txt", headers={"if-none-match": '"123"'})
     assert second_resp.status_code == 200
     assert second_resp.content == b"<file content>"
+
+
+def test_staticfiles_if_none_match_takes_precedence_over_if_modified_since(
+    tmpdir: Path, test_client_factory: TestClientFactory
+) -> None:
+    path = os.path.join(tmpdir, "example.txt")
+    file_last_modified_time = time.mktime(time.strptime("2013-10-10 23:40:00", "%Y-%m-%d %H:%M:%S"))
+    with open(path, "w") as file:
+        file.write("<file content>")
+    os.utime(path, (file_last_modified_time, file_last_modified_time))
+
+    app = StaticFiles(directory=tmpdir)
+    client = test_client_factory(app)
+    response = client.get(
+        "/example.txt",
+        headers={
+            "If-None-Match": '"123"',
+            "If-Modified-Since": "Thu, 11 Oct 2013 15:30:19 GMT",
+        },
+    )
+    assert response.status_code == 200
+    assert response.content == b"<file content>"
 
 
 def test_staticfiles_304_with_last_modified_compare_last_req(


### PR DESCRIPTION
# Summary

Fixes two HTTP edge cases in static/file responses:

- `StaticFiles` now respects `If-None-Match` precedence over `If-Modified-Since` and supports `If-None-Match: *`.
- `FileResponse` now rejects malformed `Range` headers with extra text and correctly handles suffix ranges larger than the file size.

Regression tests were added for each behavior.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

