### PR TITLE
docs: fix AuthCredentials grammar

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,7 +68,7 @@ and `SimpleUser(username)`.
 
 ## AuthCredentials
 
-It is important that authentication credentials are treated as separate concept
+It is important that authentication credentials are treated as a separate concept
 from users. An authentication scheme should be able to restrict or grant
 particular privileges independently of the user identity.
 


### PR DESCRIPTION
# Summary

Fix a small grammar issue in the `AuthCredentials` docs by adding the missing article in "a separate concept".

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
