### PR TITLE
docs: fix lint job grammar

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -108,7 +108,7 @@ Here are some common ways the test suite can fail:
   <img src="https://raw.githubusercontent.com/Kludex/starlette/main/docs/img/gh-actions-fail-check.png" alt='Failing GitHub action lint job'>
 </p>
 
-This job failing means there is either a code formatting issue or type-annotation issue.
+This job failing means there is either a code formatting issue or a type-annotation issue.
 You can look at the job output to figure out why it failed, or run the following within a shell:
 
 ```shell


### PR DESCRIPTION
# Summary

Fix a small grammar issue in the contributing guide's lint-job explanation.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
