### PR TITLE
Honor streaming responses in TestClient

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import inspect
-import io
 import json
 import math
+import queue
 import sys
+import threading
 import warnings
 from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, MutableMapping, Sequence
 from concurrent.futures import Future
@@ -196,6 +197,46 @@ class WebSocketTestSession:
         return json.loads(text)
 
 
+_STREAM_END = object()
+
+
+class _TestClientResponseStream(httpx.SyncByteStream):
+    def __init__(
+        self,
+        body_queue: queue.Queue[bytes | BaseException | object],
+        app_task: Future[None],
+        exit_stack: contextlib.ExitStack,
+    ) -> None:
+        self._body_queue = body_queue
+        self._app_task = app_task
+        self._exit_stack = exit_stack
+        self._closed = False
+
+    def __iter__(self) -> Generator[bytes, None, None]:
+        while True:
+            chunk = self._body_queue.get()
+            if chunk is _STREAM_END:
+                return
+            if isinstance(chunk, BaseException):
+                raise chunk
+            yield chunk
+
+    def close(self) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        try:
+            if not self._app_task.done():
+                self._app_task.cancel()
+            try:
+                self._app_task.result()
+            except BaseException:
+                pass
+        finally:
+            self._exit_stack.close()
+
+
 class _TestClientTransport(httpx.BaseTransport):
     def __init__(
         self,
@@ -284,10 +325,23 @@ class _TestClientTransport(httpx.BaseTransport):
 
         request_complete = False
         response_started = False
+        response_body_started = False
         response_complete: anyio.Event
-        raw_kwargs: dict[str, Any] = {"stream": io.BytesIO()}
+        response_body_started_event = threading.Event()
+        response_body_queue: queue.Queue[bytes | BaseException | object] = queue.Queue()
+        response_stream_closed = False
+        raw_kwargs: dict[str, Any] = {}
         template = None
         context = None
+
+        def close_response_stream(exc: BaseException | None = None) -> None:
+            nonlocal response_stream_closed
+
+            if response_stream_closed:
+                return
+
+            response_stream_closed = True
+            response_body_queue.put(_STREAM_END if exc is None else exc)
 
         async def receive() -> Message:
             nonlocal request_complete
@@ -318,7 +372,7 @@ class _TestClientTransport(httpx.BaseTransport):
             return {"type": "http.request", "body": body_bytes}
 
         async def send(message: Message) -> None:
-            nonlocal raw_kwargs, response_started, template, context
+            nonlocal raw_kwargs, response_started, response_body_started, template, context
 
             if message["type"] == "http.response.start":
                 assert not response_started, 'Received multiple "http.response.start" messages.'
@@ -330,33 +384,60 @@ class _TestClientTransport(httpx.BaseTransport):
                 assert not response_complete.is_set(), 'Received "http.response.body" after response completed.'
                 body = message.get("body", b"")
                 more_body = message.get("more_body", False)
-                if request.method != "HEAD":
-                    raw_kwargs["stream"].write(body)
+                response_body_started = True
+                response_body_started_event.set()
+                if request.method != "HEAD" and body:
+                    response_body_queue.put(body)
                 if not more_body:
-                    raw_kwargs["stream"].seek(0)
                     response_complete.set()
             elif message["type"] == "http.response.debug":
                 template = message["info"]["template"]
                 context = message["info"]["context"]
 
+        def on_app_done(app_task: Future[None]) -> None:
+            try:
+                app_task.result()
+            except BaseException as exc:
+                if response_started:
+                    close_response_stream(exc if self.raise_server_exceptions else None)
+            else:
+                if response_started:
+                    close_response_stream()
+            finally:
+                if not response_body_started:
+                    response_body_started_event.set()
+
+        stack = contextlib.ExitStack()
         try:
-            with self.portal_factory() as portal:
-                response_complete = portal.call(anyio.Event)
-                portal.call(self.app, scope, receive, send)
+            portal = stack.enter_context(self.portal_factory())
+            response_complete = portal.call(anyio.Event)
+            app_task = portal.start_task_soon(self.app, scope, receive, send)
+            app_task.add_done_callback(on_app_done)
+            response_body_started_event.wait()
         except BaseException as exc:
+            stack.close()
             if self.raise_server_exceptions:
                 raise exc
 
-        if self.raise_server_exceptions:
-            assert response_started, "TestClient did not receive any response."
-        elif not response_started:
+        if app_task.done() and not response_body_started:
+            try:
+                app_task.result()
+            except BaseException as exc:
+                stack.close()
+                if self.raise_server_exceptions:
+                    raise exc
+
+        if not response_started:
+            stack.close()
+            if self.raise_server_exceptions:
+                assert response_started, "TestClient did not receive any response."
             raw_kwargs = {
                 "status_code": 500,
                 "headers": [],
-                "stream": io.BytesIO(),
+                "stream": httpx.ByteStream(b""),
             }
-
-        raw_kwargs["stream"] = httpx.ByteStream(raw_kwargs["stream"].read())
+        else:
+            raw_kwargs["stream"] = _TestClientResponseStream(response_body_queue, app_task, stack)
 
         response = httpx.Response(**raw_kwargs, request=request)
         if template is not None:

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import sys
+import threading
 from asyncio import Task, current_task as asyncio_current_task
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -16,7 +17,7 @@ import trio.lowlevel
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 from starlette.routing import Route
 from starlette.testclient import ASGIInstance, TestClient
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -227,6 +228,52 @@ def test_testclient_asgi3(test_client_factory: TestClientFactory) -> None:
     client = test_client_factory(app)
     response = client.get("/")
     assert response.text == "Hello, world!"
+
+
+def test_stream_response_is_available_after_first_chunk(test_client_factory: TestClientFactory) -> None:
+    first_chunk_sent = threading.Event()
+    allow_response_to_finish = threading.Event()
+    stream_opened = threading.Event()
+    worker_errors: list[BaseException] = []
+    body = b""
+
+    def homepage(request: Request) -> StreamingResponse:
+        async def stream() -> AsyncGenerator[bytes, None]:
+            yield b"hello"
+            first_chunk_sent.set()
+            await anyio.to_thread.run_sync(allow_response_to_finish.wait)
+            yield b"world"
+
+        return StreamingResponse(stream(), media_type="text/plain")
+
+    client = test_client_factory(Starlette(routes=[Route("/", homepage)]))
+
+    def make_request() -> None:
+        nonlocal body
+
+        try:
+            with client.stream("GET", "/") as response:
+                assert response.status_code == 200
+                stream_opened.set()
+                body = b"".join(response.iter_raw())
+        except BaseException as exc:  # pragma: no cover
+            worker_errors.append(exc)
+        finally:
+            allow_response_to_finish.set()
+
+    worker = threading.Thread(target=make_request)
+    worker.start()
+
+    assert first_chunk_sent.wait(timeout=1)
+    try:
+        assert stream_opened.wait(timeout=1)
+    finally:
+        allow_response_to_finish.set()
+        worker.join(timeout=1)
+
+    assert not worker.is_alive()
+    assert not worker_errors
+    assert body == b"helloworld"
 
 
 def test_websocket_blocking_receive(test_client_factory: TestClientFactory) -> None:


### PR DESCRIPTION
## Summary
- keep the test client portal open while the app task streams the response body
- return a real sync byte stream after the first `http.response.body` instead of buffering the full body up front
- add a regression test that proves `client.stream(...)` becomes available before the streaming response completes

## Testing
- uv run pytest tests/test_testclient.py -k stream_response_is_available_after_first_chunk -q
- uv run pytest tests/test_testclient.py -q
- uv run pytest tests/test_templates.py -q
- uv run ruff check starlette/testclient.py tests/test_testclient.py

Fixes #1102