### PR TITLE
Harden GitHub Actions workflows and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       python-packages:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.11"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: scripts/install
@@ -104,6 +106,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Summary

- Set `persist-credentials: false` on all `actions/checkout` steps in `main.yml` and `publish.yml`.
- Disable the uv cache in `publish.yml` (`enable-cache: false`).
- Add a 7-day `cooldown` to both Dependabot ecosystems (`uv` and `github-actions`).

## Test plan

- [ ] CI passes on this branch.
- [ ] zizmor reports no findings (`zizmor .github/`).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.