### PR TITLE
Ignore malformed `Host` header when constructing `request.url`

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
+import re
 from collections.abc import ItemsView, Iterable, Iterator, KeysView, Mapping, MutableMapping, Sequence, ValuesView
 from shlex import shlex
-from typing import (
-    Any,
-    BinaryIO,
-    NamedTuple,
-    TypeVar,
-    cast,
-)
+from typing import Any, BinaryIO, NamedTuple, TypeVar, cast
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 
 from starlette.concurrency import run_in_threadpool
@@ -25,6 +20,9 @@ _KeyType = TypeVar("_KeyType")
 # you can only read them
 # that is, you can't do `Mapping[str, Animal]()["fido"] = Dog()`
 _CovariantValueType = TypeVar("_CovariantValueType", covariant=True)
+
+# Rejects Host header chars (/, ?, #, @, ...) that would let urlsplit produce a path differing from scope["path"].
+_HOST_RE = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])(?::[0-9]+)?$", re.IGNORECASE)
 
 
 class URL:
@@ -48,7 +46,7 @@ class URL:
                     host_header = value.decode("latin-1")
                     break
 
-            if host_header is not None:
+            if host_header is not None and _HOST_RE.fullmatch(host_header):
                 url = f"{scheme}://{host_header}{path}"
             elif server is None:
                 url = path

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -159,6 +159,32 @@ def test_url_from_scope() -> None:
     assert repr(u) == "URL('http://example.com:8000/some/path?query=string')"
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        pytest.param(b"foo/?x=", id="question-mark"),
+        pytest.param(b"foo/#", id="hash"),
+        pytest.param(b"foo/bar", id="slash"),
+        pytest.param(b"user@foo", id="at-sign"),
+        pytest.param(b"foo\\bar", id="backslash"),
+        pytest.param(b"foo bar", id="space"),
+    ],
+)
+def test_url_from_scope_with_invalid_host(host: bytes) -> None:
+    """An invalid Host header should be ignored, falling back to the server tuple."""
+    u = URL(
+        scope={
+            "scheme": "http",
+            "server": ("example.com", 80),
+            "path": "/admin",
+            "query_string": b"",
+            "headers": [(b"host", host)],
+        }
+    )
+    assert u.path == "/admin"
+    assert u.netloc == "example.com"
+
+
 def test_headers() -> None:
     h = Headers(raw=[(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
     assert "a" in h


### PR DESCRIPTION
When the `Host` header contains characters that are invalid per RFC 9110 §7.2 (`/`, `?`, `#`, `@`, `\`, spaces, ...), `urlsplit` can produce a `URL` whose `path` differs from `scope["path"]`. This makes `request.url.path` unreliable for code that inspects it.

This PR validates the `Host` header against an allowlist regex (matching Werkzeug's and Django's approach) before using it - only `[a-zA-Z0-9.-]` for domains, valid IPv6 in brackets, and optional port numbers. If the header doesn't match, we fall back to the `server` tuple from scope, the same as when no `Host` header is present.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.