### PR TITLE
Remove Hugging Face sponsor block from docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,9 +59,6 @@ Help us keep Starlette maintained and sustainable by [becoming a sponsor](https:
     <a href="https://fastapi.tiangolo.com">
         <img src="https://fastapi.tiangolo.com/img/logo-margin/logo-teal.png" alt="FastAPI" style="height: 80px;">
     </a>
-    <a href="https://huggingface.co">
-        <img src="https://huggingface.co/datasets/huggingface/brand-assets/resolve/main/hf-logo-with-title.svg" alt="Hugging Face" style="height: 80px;">
-    </a>
 </div>
 
 ## Installation


### PR DESCRIPTION
Mirrors uvicorn#2923 - removes the Hugging Face logo from the sponsors block on the docs homepage. FastAPI remains.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.