### PR TITLE
Use `"application/octet-stream"` as the `FileResponse` media type fallback

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -312,7 +312,7 @@ class FileResponse(Response):
         self.status_code = status_code
         self.filename = filename
         if media_type is None:
-            media_type = guess_type(filename or path)[0] or "text/plain"
+            media_type = guess_type(filename or path)[0] or "application/octet-stream"
         self.media_type = media_type
         self.background = background
         self.init_headers(headers)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -290,6 +290,18 @@ def test_file_response_set_media_type(tmp_path: Path, test_client_factory: TestC
     assert response.headers["content-type"] == "image/jpeg"
 
 
+def test_file_response_default_media_type(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    path = tmp_path / "file.unknownext"
+    path.write_bytes(b"<file content>")
+
+    # When the media type cannot be guessed from the filename or path, it
+    # falls back to "application/octet-stream" rather than "text/plain".
+    app = FileResponse(path=path)
+    client: TestClient = test_client_factory(app)
+    response = client.get("/")
+    assert response.headers["content-type"] == "application/octet-stream"
+
+
 def test_file_response_with_directory_raises_error(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     app = FileResponse(path=tmp_path, filename="example.png")
     client = test_client_factory(app)


### PR DESCRIPTION
# Summary

`FileResponse` falls back to `text/plain` when the media type cannot be guessed from the filename or path:

```python
if media_type is None:
    media_type = guess_type(filename or path)[0] or "text/plain"
```

For files with an unrecognized extension this means the response is served as `text/plain`, so browsers render the bytes inline as text instead of downloading the file. This was reported in discussion #3106 (an Outlook `.msg` file rendered as text rather than triggering a download).

`application/octet-stream` is the correct default for unknown content per RFC 2046 ("MIME implementations must at a minimum treat any unrecognized subtypes as being equivalent to `application/octet-stream`") and the MDN guidance. It's also what Django and Werkzeug use:

- Django: [`content_type = content_type or "application/octet-stream"`](https://github.com/django/django/blob/main/django/views/static.py)
- Werkzeug `send_file` falls back to `application/octet-stream`

The earlier choice of `text/plain` (#1027) was made on the assumption that Django used `text/plain`, which isn't the case.

This affects `FileResponse` directly and `StaticFiles`, which serves files through `FileResponse`. Passing an explicit `media_type` is unchanged.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.