### PR TITLE
Reject absolute paths in `StaticFiles.lookup_path`

### DIFF
--- a/starlette/staticfiles.py
+++ b/starlette/staticfiles.py
@@ -152,6 +152,9 @@ class StaticFiles:
         raise HTTPException(status_code=404)
 
     def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
+        # Reject absolute paths so they cannot escape the served directory.
+        if path.startswith(("/", "\\")):
+            return "", None
         for directory in self.all_directories:
             joined_path = os.path.join(directory, path)
             if self.follow_symlink:

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -603,6 +603,26 @@ def test_staticfiles_avoids_path_traversal(tmp_path: Path) -> None:
     assert exc_info.value.detail == "Not Found"
 
 
+def test_staticfiles_rejects_absolute_paths(tmp_path: Path) -> None:
+    statics_path = tmp_path / "static"
+    statics_path.mkdir()
+    app = StaticFiles(directory=statics_path)
+
+    full_path, stat_result = app.lookup_path("/etc/passwd")
+    assert full_path == ""
+    assert stat_result is None
+
+
+def test_staticfiles_rejects_absolute_windows_paths(tmp_path: Path) -> None:
+    statics_path = tmp_path / "static"
+    statics_path.mkdir()
+    app = StaticFiles(directory=statics_path)
+
+    full_path, stat_result = app.lookup_path("\\\\server\\share")
+    assert full_path == ""
+    assert stat_result is None
+
+
 def test_staticfiles_self_symlinks(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
     statics_path = tmp_path / "statics"
     statics_path.mkdir()


### PR DESCRIPTION
## Summary

`StaticFiles.lookup_path()` joins the requested path onto the served directory before resolving it. Because an absolute path makes `os.path.join` discard the directory it is joined onto, an absolute request path bypasses the directory it is supposed to be confined to.

This rejects absolute paths up front (anything starting with `/` or `\`), returning a not-found result before any filesystem resolution. Relative paths are unaffected.

## Test

Added tests covering POSIX absolute paths and backslash-prefixed paths.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
