### PR TITLE
Auto-detect async backend in TestClient

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -95,7 +95,25 @@ client = TestClient(app, client=('localhost', 8000))
 These options are passed to `anyio.start_blocking_portal()`.
 See the [anyio documentation](https://anyio.readthedocs.io/en/stable/basics.html#backend-options)
 for more information about the accepted backend options.
-By default, `asyncio` is used with default options.
+When `backend` is not specified (the default), the active async library
+is auto-detected via [sniffio](https://github.com/python-trio/sniffio),
+then by an opt-in pytest autouse fixture (see below), then by checking
+`backend_options` for trio- or asyncio-specific keys (e.g. `use_uvloop`
+implies asyncio), then by inspecting `sys.modules` (so a trio-only
+environment selects `"trio"`), and otherwise defaulting to `"asyncio"`.
+
+If you parametrize tests with anyio's pytest plugin (via the
+`anyio_backend` fixture), you can wire the parametrized backend into
+`TestClient` by adding an autouse fixture to your `conftest.py`:
+
+```python
+from starlette.testclient import make_anyio_backend_autouse_fixture
+
+_publish_anyio_backend = make_anyio_backend_autouse_fixture()
+```
+
+With this in place, `TestClient(app)` (no `backend=` kwarg) picks up the
+backend that anyio parametrized the test with.
 
 To run `Trio`, pass `backend="trio"`. For example:
 

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -10,6 +10,7 @@ import warnings
 from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, MutableMapping, Sequence
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
+from contextvars import ContextVar
 from types import GeneratorType
 from typing import (
     Any,
@@ -23,6 +24,7 @@ from urllib.parse import unquote, urljoin
 import anyio
 import anyio.abc
 import anyio.from_thread
+import sniffio
 from anyio.streams.stapled import StapledObjectStream
 
 from starlette._utils import is_async_callable
@@ -74,6 +76,99 @@ class _WrapASGI2:
 class _AsyncBackend(TypedDict):
     backend: str
     backend_options: dict[str, Any]
+
+
+_pytest_backend_cvar: ContextVar[str | None] = ContextVar("_pytest_backend_cvar", default=None)
+
+
+# Option keys that disambiguate the backend when set in ``backend_options``.
+# Both anyio.run signatures use distinct keyword names, so the presence of any
+# of these keys uniquely identifies the intended backend.
+_TRIO_OPTION_KEYS = frozenset(
+    {"clock", "instruments", "restrict_keyboard_interrupt_to_checkpoints", "strict_exception_groups"}
+)
+_ASYNCIO_OPTION_KEYS = frozenset({"debug", "loop_factory", "use_uvloop"})
+
+
+def _detect_async_backend(backend_options: Mapping[str, Any] | None = None) -> Literal["asyncio", "trio"]:
+    """Detect which async backend to use for the blocking portal.
+
+    Detection order:
+    1. ``sniffio.current_async_library()`` — picks up the currently running
+       async library, if there is one.
+    2. ``_pytest_backend_cvar`` — set by the autouse fixture returned by
+       ``make_anyio_backend_autouse_fixture()``, which mirrors anyio's
+       parametrized ``anyio_backend_name`` fixture into a ContextVar
+       readable from sync test code.
+    3. ``backend_options`` keys — trio and asyncio use disjoint option
+       names, so the presence of any trio-specific or asyncio-specific
+       key disambiguates.
+    4. ``sys.modules`` inspection — if only one of ``trio`` / ``asyncio`` is
+       imported, use that one. If both (or neither) are imported, fall back
+       to ``"asyncio"``.
+    """
+    try:
+        library = sniffio.current_async_library()
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    else:
+        if library in ("asyncio", "trio"):
+            return library  # type: ignore[return-value]
+
+    pytest_backend = _pytest_backend_cvar.get()
+    if pytest_backend in ("asyncio", "trio"):
+        return pytest_backend  # type: ignore[return-value]
+
+    if backend_options:
+        option_keys = backend_options.keys()
+        if option_keys & _TRIO_OPTION_KEYS:
+            return "trio"
+        if option_keys & _ASYNCIO_OPTION_KEYS:
+            return "asyncio"
+
+    if "trio" in sys.modules:
+        if "asyncio" not in sys.modules:
+            return "trio"
+        warnings.warn(
+            "Both `trio` and `asyncio` are imported; TestClient is defaulting to "
+            "`asyncio`. Pass `backend=` explicitly to silence this warning.",
+            stacklevel=3,
+        )
+    return "asyncio"
+
+
+@contextlib.contextmanager
+def _set_pytest_backend(backend: str | None) -> Generator[None, None, None]:
+    """Publish the parametrized anyio backend into ``_pytest_backend_cvar``."""
+    token = _pytest_backend_cvar.set(backend)
+    try:
+        yield
+    finally:
+        _pytest_backend_cvar.reset(token)
+
+
+def make_anyio_backend_autouse_fixture() -> Any:
+    """Return an autouse pytest fixture that publishes the active anyio
+    backend to the ``starlette.testclient`` ContextVar.
+
+    Add to a test module or ``conftest.py`` as e.g.::
+
+        from starlette.testclient import make_anyio_backend_autouse_fixture
+
+        _publish_anyio_backend = make_anyio_backend_autouse_fixture()
+
+    With this fixture in place, ``TestClient(app)`` (no ``backend=`` kwarg)
+    will pick up the backend that anyio's pytest plugin has parametrized
+    the test with.
+    """
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def _publish_anyio_backend(anyio_backend_name: str) -> Generator[None, None, None]:
+        with _set_pytest_backend(anyio_backend_name):
+            yield
+
+    return _publish_anyio_backend
 
 
 class _Upgrade(Exception):
@@ -376,13 +471,15 @@ class TestClient(httpx.Client):
         base_url: str = "http://testserver",
         raise_server_exceptions: bool = True,
         root_path: str = "",
-        backend: Literal["asyncio", "trio"] = "asyncio",
+        backend: Literal["asyncio", "trio"] | None = None,
         backend_options: dict[str, Any] | None = None,
         cookies: httpx._types.CookieTypes | None = None,
         headers: dict[str, str] | None = None,
         follow_redirects: bool = True,
         client: tuple[str, int] = ("testclient", 50000),
     ) -> None:
+        if backend is None:
+            backend = _detect_async_backend(backend_options)
         self.async_backend = _AsyncBackend(backend=backend, backend_options=backend_options or {})
         if _is_asgi3(app):
             asgi_app = app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Literal
+from typing import Any
 
 import pytest
 
-from starlette.testclient import TestClient
+from starlette.testclient import TestClient, make_anyio_backend_autouse_fixture
 from tests.types import TestClientFactory
+
+# Publishes anyio_backend_name into starlette.testclient's ContextVar so
+# that TestClient() without a backend kwarg picks up the parametrized
+# backend automatically.
+_publish_anyio_backend = make_anyio_backend_autouse_fixture()
 
 
 @pytest.fixture
-def test_client_factory(
-    anyio_backend_name: Literal["asyncio", "trio"],
-    anyio_backend_options: dict[str, Any],
-) -> TestClientFactory:
-    # anyio_backend_name defined by:
-    # https://anyio.readthedocs.io/en/stable/testing.html#specifying-the-backends-to-run-on
-    return functools.partial(
-        TestClient,
-        backend=anyio_backend_name,
-        backend_options=anyio_backend_options,
-    )
+def test_client_factory(anyio_backend_options: dict[str, Any]) -> TestClientFactory:
+    # anyio_backend_name is consumed by the autouse fixture above; the
+    # TestClient will auto-detect the backend from the ContextVar.
+    return functools.partial(TestClient, backend_options=anyio_backend_options)

--- a/tests/test_testclient.py
+++ b/tests/test_testclient.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import sys
+import warnings
 from asyncio import Task, current_task as asyncio_current_task
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -64,6 +65,118 @@ def test_use_testclient_in_endpoint(test_client_factory: TestClientFactory) -> N
     client = test_client_factory(app)
     response = client.get("/")
     assert response.json() == {"mock": "example"}
+
+
+def test_testclient_detects_backend() -> None:
+    """
+    When ``backend`` is not specified, the TestClient should detect the
+    currently active async library via sniffio, falling back to inspecting
+    ``sys.modules`` so that trio-only environments default to trio.
+    """
+    from starlette.testclient import _pytest_backend_cvar
+
+    # Suppress the autouse fixture's cvar value so we exercise the sniffio
+    # and sys.modules detection paths directly.
+    token = _pytest_backend_cvar.set(None)
+    try:
+        # Both trio and asyncio are imported in this test process, so the
+        # sys.modules tier triggers the ambiguity warning before defaulting
+        # to asyncio.
+        with pytest.warns(UserWarning, match="Pass `backend=` explicitly"):
+            client = TestClient(mock_service)
+        assert client.async_backend["backend"] == "asyncio"
+
+        async def detect() -> str:
+            client = TestClient(mock_service)
+            return client.async_backend["backend"]
+
+        # sniffio detects the running library — no ambiguity warning even
+        # though both modules are imported.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert trio.run(detect) == "trio"
+            assert anyio.run(detect, backend="asyncio") == "asyncio"
+    finally:
+        _pytest_backend_cvar.reset(token)
+
+
+def test_testclient_picks_up_pytest_backend_cvar(anyio_backend_name: str) -> None:
+    """
+    The autouse fixture wired in ``tests/conftest.py`` publishes the
+    parametrized anyio backend into a ContextVar that ``TestClient``
+    consults when no explicit ``backend`` is given.
+    """
+    client = TestClient(mock_service)
+    assert client.async_backend["backend"] == anyio_backend_name
+
+
+def test_testclient_detects_backend_from_options() -> None:
+    """
+    When sniffio and the ContextVar are both unset, the presence of
+    backend-specific keys in ``backend_options`` disambiguates the
+    intended backend.
+    """
+    from starlette.testclient import _pytest_backend_cvar
+
+    token = _pytest_backend_cvar.set(None)
+    try:
+        client = TestClient(mock_service, backend_options={"use_uvloop": False})
+        assert client.async_backend["backend"] == "asyncio"
+
+        client = TestClient(mock_service, backend_options={"restrict_keyboard_interrupt_to_checkpoints": True})
+        assert client.async_backend["backend"] == "trio"
+
+        # backend_options without any recognised key falls through to the
+        # sys.modules tier (which here warns and defaults to asyncio).
+        with pytest.warns(UserWarning, match="Pass `backend=` explicitly"):
+            client = TestClient(mock_service, backend_options={"unknown_key": True})
+        assert client.async_backend["backend"] == "asyncio"
+    finally:
+        _pytest_backend_cvar.reset(token)
+
+
+def test_testclient_explicit_backend_skips_detection() -> None:
+    """An explicit ``backend=`` argument bypasses auto-detection entirely."""
+    client = TestClient(mock_service, backend="asyncio")
+    assert client.async_backend["backend"] == "asyncio"
+
+
+def test_testclient_detects_backend_from_sys_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Cover the sys.modules tier branches that aren't reachable from the
+    normal pytest process (where both ``trio`` and ``asyncio`` are always
+    imported).
+    """
+    from starlette.testclient import _pytest_backend_cvar
+
+    def _no_async_library() -> str:
+        raise sniffio.AsyncLibraryNotFoundError
+
+    monkeypatch.setattr(sniffio, "current_async_library", _no_async_library)
+    token = _pytest_backend_cvar.set(None)
+    try:
+        # Sniffio returns a library we don't support — fall through.
+        monkeypatch.setattr(sniffio, "current_async_library", lambda: "curio")
+        with pytest.warns(UserWarning, match="Pass `backend=` explicitly"):
+            assert TestClient(mock_service).async_backend["backend"] == "asyncio"
+        monkeypatch.setattr(sniffio, "current_async_library", _no_async_library)
+
+        # Trio imported but asyncio is not — pick trio.
+        with monkeypatch.context() as m:
+            m.delitem(sys.modules, "asyncio")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                assert TestClient(mock_service).async_backend["backend"] == "trio"
+
+        # Neither trio nor asyncio is imported — default to asyncio with no warning.
+        with monkeypatch.context() as m:
+            m.delitem(sys.modules, "trio")
+            m.delitem(sys.modules, "asyncio")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                assert TestClient(mock_service).async_backend["backend"] == "asyncio"
+    finally:
+        _pytest_backend_cvar.reset(token)
 
 
 def test_testclient_headers_behavior() -> None:


### PR DESCRIPTION
## Summary

Previously `TestClient` defaulted to `backend="asyncio"`, forcing trio users to repeatedly pass `backend="trio"` or build a custom client factory; and anyio users have to figure out backend detection.

This patch teaches `TestClient` itself to figure out which backend is appropriate in most cases, with techniques falling through from `sniffio` to pytest config to `backend_options` inspection to `sys.modules`, ultimately warning if the question remains ambiguous.

I proposed something very similar in agronholm/anyio#1151 last week, which resolved that the feature should be added directly to downstream libraries.  So here we go!

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion.
        (it seemed about as easy to open a PR for discussion as for an issue though, so here we are 🙂)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.