### PR TITLE
Support httpx2 in the test client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ filterwarnings = [
     "ignore: starlette.middleware.wsgi is deprecated and will be removed in a future release.*:DeprecationWarning",
     "ignore: Async generator 'starlette.requests.Request.stream' was garbage collected before it had been exhausted.*:ResourceWarning",
     "ignore: Use 'content=<...>' to upload raw bytes/text content.:DeprecationWarning",
+    "ignore: Using `httpx` with `starlette.testclient` is deprecated.*:starlette.exceptions.StarletteDeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/starlette/exceptions.py
+++ b/starlette/exceptions.py
@@ -31,3 +31,13 @@ class WebSocketException(Exception):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}(code={self.code!r}, reason={self.reason!r})"
+
+
+class StarletteDeprecationWarning(UserWarning):
+    """A custom deprecation warning for Starlette.
+
+    Unlike the built-in DeprecationWarning, this inherits from UserWarning to ensure it is visible by default, helping
+    users discover deprecated features without needing to enable warnings explicitly.
+
+    Reference: https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries
+    """

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -27,6 +27,7 @@ import anyio.from_thread
 from anyio.streams.stapled import StapledObjectStream
 
 from starlette._utils import is_async_callable
+from starlette.exceptions import StarletteDeprecationWarning
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
@@ -50,8 +51,6 @@ else:
                 "    $ pip install httpx2\n"
             )
         else:
-            from starlette.exceptions import StarletteDeprecationWarning
-
             warnings.warn(
                 "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
                 StarletteDeprecationWarning,

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -12,6 +12,7 @@ from concurrent.futures import Future
 from contextlib import AbstractContextManager
 from types import GeneratorType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     TypedDict,
@@ -34,14 +35,28 @@ if sys.version_info >= (3, 11):  # pragma: no cover
 else:  # pragma: no cover
     from typing_extensions import Self
 
-try:
+if TYPE_CHECKING:
     import httpx
-except ModuleNotFoundError:  # pragma: no cover
-    raise RuntimeError(
-        "The starlette.testclient module requires the httpx package to be installed.\n"
-        "You can install this with:\n"
-        "    $ pip install httpx\n"
-    )
+else:
+    try:
+        import httpx2 as httpx
+    except ModuleNotFoundError:
+        try:
+            import httpx
+        except ModuleNotFoundError:  # pragma: no cover
+            raise RuntimeError(
+                "The starlette.testclient module requires the httpx2 package to be installed.\n"
+                "You can install this with:\n"
+                "    $ pip install httpx2\n"
+            )
+        else:
+            from starlette.exceptions import StarletteDeprecationWarning
+
+            warnings.warn(
+                "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
+                StarletteDeprecationWarning,
+                stacklevel=2,
+            )
 _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]


### PR DESCRIPTION
`starlette.testclient` now prefers `httpx2` when installed, falling back to `httpx`. The fallback emits a `StarletteDeprecationWarning` urging migration; if neither is installed, the existing `RuntimeError` is raised pointing at `httpx2`.

Non-breaking: users with only `httpx` installed keep working, just warned.

- Adds `StarletteDeprecationWarning(UserWarning)` to `starlette/exceptions.py` (from #3119) - inherits from `UserWarning` so it's visible by default.
- `TYPE_CHECKING` guard keeps mypy typing against `httpx` (httpx2 has no stubs yet).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.