### PR TITLE
fix: replace assert with ValueError in Response.set_cookie()

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -117,11 +117,8 @@ class Response:
         if httponly:
             cookie[key]["httponly"] = True
         if samesite is not None:
-            assert samesite.lower() in [
-                "strict",
-                "lax",
-                "none",
-            ], "samesite must be either 'strict', 'lax' or 'none'"
+            if samesite.lower() not in ("strict", "lax", "none"):
+                raise ValueError("samesite must be either 'strict', 'lax' or 'none'")
             cookie[key]["samesite"] = samesite
         if partitioned:
             if sys.version_info < (3, 14):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -467,6 +467,18 @@ def test_set_cookie_samesite_none(test_client_factory: TestClientFactory) -> Non
     assert response.headers["set-cookie"] == "mycookie=myvalue; Path=/"
 
 
+def test_set_cookie_samesite_invalid(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        response = Response("Hello, world!", media_type="text/plain")
+        with pytest.raises(ValueError):
+            response.set_cookie("mycookie", "myvalue", samesite="invalid")
+        await response(scope, receive, send)
+
+    client = test_client_factory(app)
+    response = client.get("/")
+    assert response.text == "Hello, world!"
+
+
 @pytest.mark.parametrize(
     "expires",
     [

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -471,7 +471,7 @@ def test_set_cookie_samesite_invalid(test_client_factory: TestClientFactory) -> 
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         response = Response("Hello, world!", media_type="text/plain")
         with pytest.raises(ValueError):
-            response.set_cookie("mycookie", "myvalue", samesite="invalid")
+            response.set_cookie("mycookie", "myvalue", samesite="invalid")  # type: ignore[arg-type]
         await response(scope, receive, send)
 
     client = test_client_factory(app)


### PR DESCRIPTION
Using `assert` for user-facing validation is unsafe because Python disables assertions when run with the `-O` (optimise) flag. This silently skips the `samesite` check and allows an invalid value to be set in the cookie header.

This PR replaces the `assert` statement with an explicit check and a `ValueError`, which is consistent with the validation already used for `partitioned` cookies in the same method.