### PR TITLE
chore: improve starlette maintenance path

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -208,7 +208,7 @@ class Secret:
     You should cast the value to `str` at the point it is required.
     """
 
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         self._value = value
 
     def __repr__(self) -> str:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -509,3 +509,20 @@ def test_multidict() -> None:
     assert q.getlist("a") == ["123"]
     q.update([("a", "456")], a="789", b="123")
     assert q == MultiDict([("a", "456"), ("a", "789"), ("b", "123")])
+
+
+def test_datastructures_edge_cases() -> None:
+    # MutableHeaders: deleting a missing key (case-insensitive) is a no-op
+    h = MutableHeaders(raw=[(b"a", b"1")])
+    del h["B"]
+    assert h.raw == [(b"a", b"1")]
+
+    # QueryParams: bytes input preserves repeated param ordering
+    q = QueryParams(b"a=123&a=456&b=789")
+    assert q.getlist("a") == ["123", "456"]
+    assert str(q) == "a=123&a=456&b=789"
+
+    # URL.replace with empty path
+    u = URL("https://example.org/path/to/somewhere?abc=123")
+    new = u.replace(path="")
+    assert str(new) == "https://example.org?abc=123"


### PR DESCRIPTION
Summary:
- Add narrow edge-case unit tests in tests/test_datastructures.py covering under-tested branches of MutableHeaders / QueryParams / URL in starlette/datastructures.py (e.g. case-insensitive header delete on missing key, repeated query param ordering, URL.replace with empty path), plus tighten/add a missing return type annotation on a small helper in datastructures.py where mypy-strict would flag it.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.