### PR TITLE
Add assert error for requires() when request param is not Request type

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -45,7 +45,10 @@ def requires(
             @functools.wraps(func)
             async def websocket_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
                 websocket = kwargs.get("websocket", args[idx] if idx < len(args) else None)
-                assert isinstance(websocket, WebSocket)
+                assert isinstance(websocket, WebSocket), (
+                    "Parameter with name 'websocket' is required to be of type 'WebSocket'"
+                    f" not '{type(websocket).__name__}'"
+                )
 
                 if not has_required_scope(websocket, scopes_list):
                     await websocket.close()
@@ -59,7 +62,9 @@ def requires(
             @functools.wraps(func)
             async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> Any:
                 request = kwargs.get("request", args[idx] if idx < len(args) else None)
-                assert isinstance(request, Request)
+                assert isinstance(request, Request), (
+                    f"Parameter with name 'request' is required to be of type 'Request' not '{type(request).__name__}'"
+                )
 
                 if not has_required_scope(request, scopes_list):
                     if redirect is not None:
@@ -76,7 +81,9 @@ def requires(
             @functools.wraps(func)
             def sync_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> Any:
                 request = kwargs.get("request", args[idx] if idx < len(args) else None)
-                assert isinstance(request, Request)
+                assert isinstance(request, Request), (
+                    f"Parameter with name 'request' is required to be of type 'Request' not '{type(request).__name__}'"
+                )
 
                 if not has_required_scope(request, scopes_list):
                     if redirect is not None:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Adding `requires('scope')` to a function that has a `request` param that is not of type `Request` currently throws an `AssertionError`:
```
  File ".venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File ".venv/lib/python3.14/site-packages/starlette/authentication.py", line 79, in sync_wrapper
    assert isinstance(request, Request)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
AssertionError
```

Which isn't much of a problem specifically in `starlette` since all functions that handle `post` requests will do so from accessing `request.json()`. However, in `fastapi`, body parameters are pydantic models that can be any name and type, including `request`.  

This change is to add a message to the assert to better communicate what the issue might be for the case where the request parameter is not of type `Request`:
```
  File ".venv/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File ".venv/lib/python3.14/site-packages/starlette/authentication.py", line 84, in sync_wrapper
    assert isinstance(request, Request), (
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
AssertionError: Parameter with name 'request' is required to be of type 'Request' not 'ExampleRequest'
```

MRE:
```python
import fastapi
import uvicorn
from starlette.authentication import AuthenticationBackend, AuthCredentials, SimpleUser, requires
from starlette.middleware import Middleware
from starlette.middleware.authentication import AuthenticationMiddleware
from starlette.responses import PlainTextResponse
import pydantic


class ExampleRequest(pydantic.BaseModel):
    name: str


class BasicAuthBackend(AuthenticationBackend):
    async def authenticate(self, conn):
        return AuthCredentials(["authenticated"]), SimpleUser("username")


middleware = [
    Middleware(AuthenticationMiddleware, backend=BasicAuthBackend())
]

app = fastapi.FastAPI(middleware=middleware)



@app.post("/")
@requires("authenticated")
def example(request: ExampleRequest):
    return PlainTextResponse(f'Hello, {request.name}!')


uvicorn.run(app, host='0.0.0.0', port=8000)
```

```bash
curl -X 'POST' \
  'http://127.0.0.1:8000/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "name": "string"
}'
```

Changing `request: ExampleRequest` to `body: ExampleRequest` and adding a `request: Request` to the function params above works fine.


# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] ~~I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.~~ non functional change
- [X] ~~I've updated the documentation accordingly.~~ 
