### PR TITLE
Guard empty hostname in `URL.replace()`

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -123,7 +123,7 @@ class URL:
                 netloc = self.netloc
                 _, _, hostname = netloc.rpartition("@")
 
-                if hostname[-1] != "]":
+                if hostname and hostname[-1] != "]":
                     hostname = hostname.rsplit(":", 1)[0]
 
             netloc = hostname

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -62,6 +62,15 @@ def test_url() -> None:
     assert url.replace(username="u") == URL("http://u@host:80")
 
 
+def test_url_replace_with_empty_netloc() -> None:
+    # URLs with no netloc (e.g. relative URLs) used to raise IndexError in
+    # replace() because the empty hostname was indexed with hostname[-1].
+    assert URL("/path").replace(port=8080) == URL("//:8080/path")
+    assert URL("").replace(port=8080) == URL("//:8080")
+    assert URL("http://").replace(port=8080) == URL("http://:8080")
+    assert URL("/path").replace(hostname="example.com") == URL("//example.com/path")
+
+
 def test_url_query_params() -> None:
     u = URL("https://example.org/path/?page=3")
     assert u.query == "page=3"


### PR DESCRIPTION
A `URL` with no netloc raises `IndexError: string index out of range` from `URL.replace()` when `port`/`username`/`password` is given without a `hostname`:

```python
URL("/path").replace(port=8080)        # IndexError
URL("").replace(port=8080)             # IndexError
URL("http://").replace(username="u")   # IndexError
```

In `replace()`, when no `hostname` kwarg is passed it derives the hostname via `netloc.rpartition("@")`, which yields an empty string for these URLs. The subsequent `hostname[-1] != "]"` check then indexes an empty string and blows up. The trailing-`]` check (IPv6 literal) is only meaningful for a non-empty hostname, so guarding the index is enough:

```python
if hostname and hostname[-1] != "]":
```

Added `test_url_replace_with_empty_netloc`, which fails with `IndexError` before the fix and passes after, covering the relative-path, empty-string and scheme-only cases. This is the same one-line fix as #3154, which was closed for not having a test.
