### PR TITLE
Use same module (httpx|httpx2) for type checking as for runtime

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -12,7 +12,6 @@ from concurrent.futures import Future
 from contextlib import AbstractContextManager
 from types import GeneratorType
 from typing import (
-    TYPE_CHECKING,
     Any,
     Literal,
     TypedDict,
@@ -36,26 +35,23 @@ if sys.version_info >= (3, 11):  # pragma: no cover
 else:  # pragma: no cover
     from typing_extensions import Self
 
-if TYPE_CHECKING:
-    import httpx
-else:
+try:
+    import httpx2 as httpx
+except ModuleNotFoundError:  # pragma: no cover
     try:
-        import httpx2 as httpx
-    except ModuleNotFoundError:  # pragma: no cover
-        try:
-            import httpx
-        except ModuleNotFoundError:
-            raise RuntimeError(
-                "The starlette.testclient module requires the httpx2 package to be installed.\n"
-                "You can install this with:\n"
-                "    $ pip install httpx2\n"
-            )
-        else:
-            warnings.warn(
-                "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
-                StarletteDeprecationWarning,
-                stacklevel=2,
-            )
+        import httpx
+    except ModuleNotFoundError:
+        raise RuntimeError(
+            "The starlette.testclient module requires the httpx2 package to be installed.\n"
+            "You can install this with:\n"
+            "    $ pip install httpx2\n"
+        )
+    else:
+        warnings.warn(
+            "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
+            StarletteDeprecationWarning,
+            stacklevel=2,
+        )
 _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]

--- a/tests/types.py
+++ b/tests/types.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
-import httpx
+try:
+    import httpx2 as httpx
+except ModuleNotFoundError:
+    import httpx
 
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp


### PR DESCRIPTION
# Summary

Using different module when type checking (httpx) compared to runtime (httpx2) will cause type
checkers like pyright to fail. This PR solves this issue mentioned in #3302 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

<!-- Message of single commit: -->

Use same module (httpx|httpx2) for type checking as for runtime