### PR TITLE
Use same module (httpx|httpx2) for type checking as for runtime

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -37,7 +37,7 @@ else:  # pragma: no cover
     from typing_extensions import Self
 
 if TYPE_CHECKING:
-    import httpx
+    import httpx2 as httpx
 else:
     try:
         import httpx2 as httpx


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Using different module when type checking (httpx) compared to runtime (httpx2) will cause type
checkers like pyright to fail. This PR solves this issue mentioned in #3302

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

<!-- Message of single commit: -->

Use same module (httpx|httpx2) for type checking as for runtime