### PR TITLE
Clamp oversized suffix ranges in `FileResponse`

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -513,7 +513,7 @@ class FileResponse(Response):
             end_str = end_str.strip()
 
             try:
-                start = int(start_str) if start_str else file_size - int(end_str)
+                start = int(start_str) if start_str else max(file_size - int(end_str), 0)
                 end = int(end_str) + 1 if start_str and end_str and int(end_str) < file_size else file_size
                 ranges.append((start, end))
             except ValueError:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -938,6 +938,16 @@ def test_file_response_suffix_range(file_response_client: TestClient) -> None:
     assert response.content == README.encode("utf8")[-100:]
 
 
+def test_file_response_suffix_range_larger_than_file(file_response_client: TestClient) -> None:
+    response = file_response_client.get("/", headers={"Range": "bytes=-1000"})
+
+    file_size = len(README.encode("utf8"))
+    assert response.status_code == 206
+    assert response.headers["content-range"] == f"bytes 0-{file_size - 1}/{file_size}"
+    assert response.headers["content-length"] == str(file_size)
+    assert response.content == README.encode("utf8")
+
+
 def test_file_response_multiple_calls(file_response_client: TestClient) -> None:
     response = file_response_client.get("/", headers={"Range": "bytes=0-100"})
     assert response.status_code == 206


### PR DESCRIPTION
## Summary

Clamp suffix byte ranges whose requested length is larger than the file size so FileResponse returns the full representation instead of treating the range as unsatisfiable.

For example, `Range: bytes=-1000` against a 526-byte file should produce `206` with `Content-Range: bytes 0-525/526`.

## Root cause

`_parse_ranges` calculated suffix range starts with `file_size - suffix_length`. When the suffix length exceeded the file size, that produced a negative start offset, which `_parse_range_header` rejected with `416`.

## Checks

- `uv run pytest tests/test_responses.py::test_file_response_suffix_range_larger_than_file -q`
- `uv run pytest tests/test_responses.py -k "file_response_range or file_response_suffix_range" -q`
- `uv run pytest tests/test_responses.py -q`
- `uv run ruff check starlette/responses.py tests/test_responses.py`