### PR TITLE
Raise WebSocketDisconnect after websocket close

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect()
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 


### PR DESCRIPTION
# Summary

Closes #2766.

This raises `WebSocketDisconnect` when `WebSocket.send()` is called after the application state is already disconnected. The duplicate-close regression test now expects the existing websocket disconnect exception.

# Tests

- `pytest tests/test_websockets.py::test_duplicate_close`
- `pytest tests/test_websockets.py`
- `ruff format --check --diff starlette/websockets.py tests/test_websockets.py`
- `ruff check starlette/websockets.py tests/test_websockets.py`
- `python -m py_compile starlette/websockets.py tests/test_websockets.py`
- `git diff --check`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This does not apply to typos.)
- [x] I added a test for the change.
