### PR TITLE
Raise WebSocketDisconnect after duplicate close

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -95,7 +95,7 @@ class WebSocket(HTTPConnection[StateT]):
                 self.application_state = WebSocketState.DISCONNECTED
             await self._send(message)
         else:
-            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+            raise WebSocketDisconnect()
 
     async def accept(
         self,

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -488,7 +488,7 @@ def test_duplicate_close(test_client_factory: TestClientFactory) -> None:
         await websocket.close()
 
     client = test_client_factory(app)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/"):
             pass  # pragma: no cover
 


### PR DESCRIPTION
Fixes #2766.

## Summary
- Raise `WebSocketDisconnect` when application code calls `send()` after a close has already been sent
- Update duplicate close coverage to expect the WebSocket disconnect exception instead of a generic runtime error
- Leave the receive-after-disconnect path unchanged

## Tests
- Red before fix: `uv run pytest tests/test_websockets.py::test_duplicate_close -q` failed with `RuntimeError: Cannot call "send" once a close message has been sent.`
- `uv run pytest tests/test_websockets.py::test_duplicate_close -q`
- `uv run pytest tests/test_websockets.py -q`
- `uv run ruff check starlette/websockets.py tests/test_websockets.py`
- `uv run mypy starlette/websockets.py`
- `git diff --check`
