### PR TITLE
Fix IndexError in URL.replace() on a URL with no authority

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -123,7 +123,7 @@ class URL:
                 netloc = self.netloc
                 _, _, hostname = netloc.rpartition("@")
 
-                if hostname[-1] != "]":
+                if hostname and hostname[-1] != "]":
                     hostname = hostname.rsplit(":", 1)[0]
 
             netloc = hostname

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -61,6 +61,13 @@ def test_url() -> None:
     url = URL("http://host:80")
     assert url.replace(username="u") == URL("http://u@host:80")
 
+    # Replacing authority components on a URL that has no authority should not
+    # raise, and should add the requested component to the netloc.
+    url = URL("/path?a=1")
+    assert url.replace(port=8080) == URL("//:8080/path?a=1")
+    assert url.replace(port=8080).port == 8080
+    assert url.replace(username="u") == URL("//u@/path?a=1")
+
 
 def test_url_query_params() -> None:
     u = URL("https://example.org/path/?page=3")


### PR DESCRIPTION
URL.replace() raises IndexError when you change an authority component on a URL that has no authority. This happens for path-only URLs, where the netloc is empty.

A small reproduction:

```python
from starlette.datastructures import URL

URL("/path").replace(port=8080)      # IndexError: string index out of range
URL("/path").replace(username="u")   # IndexError: string index out of range
```

The cause is in the branch that derives the existing hostname when the caller does not pass one. The netloc is empty, so after rpartition("@") the hostname is also empty, and the bracket check then indexes an empty string:

```python
if hostname[-1] != "]":
    hostname = hostname.rsplit(":", 1)[0]
```

This guards that check so the split is only attempted when there is a hostname to split. A path-only URL now gains the requested component in its netloc instead of crashing, which matches what already happens when you pass hostname explicitly:

```python
URL("/path").replace(hostname="h", port=8080)  # "//h:8080/path", already works
URL("/path").replace(port=8080)                # now "//:8080/path", was IndexError
```

I added assertions to the existing test_url test covering the port and username cases on a URL with no authority. The new cases fail with IndexError before the change and pass after it. ruff check and ruff format --check both pass on the touched files.
