### PR TITLE
docs: fix TestClient examples and default client host

### DIFF
--- a/docs/testclient.md
+++ b/docs/testclient.md
@@ -81,7 +81,7 @@ case you should use `client = TestClient(app, raise_server_exceptions=False)`.
 
 ### Change client address
 
-By default, the TestClient will set the client host to `"testserver"` and the port to `50000`.
+By default, the TestClient will set the client host to `"testclient"` and the port to `50000`.
 
 You can change the client address by setting the `client` attribute of the `TestClient` instance:
 
@@ -100,7 +100,7 @@ By default, `asyncio` is used with default options.
 To run `Trio`, pass `backend="trio"`. For example:
 
 ```python
-def test_app()
+def test_app():
     with TestClient(app, backend="trio") as client:
        ...
 ```
@@ -108,7 +108,7 @@ def test_app()
 To run `asyncio` with `uvloop`, pass `backend_options={"use_uvloop": True}`.  For example:
 
 ```python
-def test_app()
+def test_app():
     with TestClient(app, backend_options={"use_uvloop": True}) as client:
        ...
 ```


### PR DESCRIPTION
A few issues in `docs/testclient.md`:

- The two `def test_app()` examples under **Selecting the Async backend** are missing the trailing colon, so the snippets are not valid Python.
- The **Change client address** section states the default client host is `"testserver"`, but `TestClient` defaults `client` to `("testclient", 50000)` (`"testserver"` is the `base_url`). `request.client` is therefore `("testclient", 50000)`, as asserted in `tests/test_testclient.py`. The docs now say `"testclient"`.

Docs only — no behavior change.
