### PR TITLE
Adjust testclient typing and warnings

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -11,14 +11,7 @@ from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, M
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
 from types import GeneratorType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    TypedDict,
-    TypeGuard,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeGuard, cast
 from urllib.parse import unquote, urljoin
 
 import anyio
@@ -49,13 +42,14 @@ else:
                 "The starlette.testclient module requires the httpx2 package to be installed.\n"
                 "You can install this with:\n"
                 "    $ pip install httpx2\n"
-            )
+            ) from None
         else:
             warnings.warn(
                 "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
                 StarletteDeprecationWarning,
                 stacklevel=2,
             )
+
 _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
@@ -118,7 +112,7 @@ class WebSocketTestSession:
         self.portal_factory = portal_factory
         self.extra_headers = None
 
-    def __enter__(self) -> WebSocketTestSession:
+    def __enter__(self) -> Self:
         with contextlib.ExitStack() as stack:
             self.portal = portal = stack.enter_context(self.portal_factory())
             fut, cs = portal.start_task(self._run)
@@ -454,6 +448,7 @@ class TestClient(httpx.Client):
                 "You should not use the 'timeout' argument with the TestClient. "
                 "See https://github.com/Kludex/starlette/issues/1108 for more information.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         url = self._merge_url(url)
         return super().request(

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -11,14 +11,7 @@ from collections.abc import Awaitable, Callable, Generator, Iterable, Mapping, M
 from concurrent.futures import Future
 from contextlib import AbstractContextManager
 from types import GeneratorType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    TypedDict,
-    TypeGuard,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeGuard, cast
 from urllib.parse import unquote, urljoin
 
 import anyio
@@ -31,13 +24,14 @@ from starlette.exceptions import StarletteDeprecationWarning
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
-if sys.version_info >= (3, 11):  # pragma: no cover
-    from typing import Self
-else:  # pragma: no cover
-    from typing_extensions import Self
-
 if TYPE_CHECKING:
     import httpx2 as httpx
+
+    if sys.version_info >= (3, 11):  # pragma: no cover
+        from typing import Self
+    else:  # pragma: no cover
+        from typing_extensions import Self
+
 else:
     try:
         import httpx2 as httpx
@@ -49,13 +43,14 @@ else:
                 "The starlette.testclient module requires the httpx2 package to be installed.\n"
                 "You can install this with:\n"
                 "    $ pip install httpx2\n"
-            )
+            ) from None
         else:
             warnings.warn(
                 "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
                 StarletteDeprecationWarning,
                 stacklevel=2,
             )
+
 _PortalFactoryType = Callable[[], AbstractContextManager[anyio.abc.BlockingPortal]]
 
 ASGIInstance = Callable[[Receive, Send], Awaitable[None]]
@@ -118,7 +113,7 @@ class WebSocketTestSession:
         self.portal_factory = portal_factory
         self.extra_headers = None
 
-    def __enter__(self) -> WebSocketTestSession:
+    def __enter__(self) -> Self:
         with contextlib.ExitStack() as stack:
             self.portal = portal = stack.enter_context(self.portal_factory())
             fut, cs = portal.start_task(self._run)
@@ -203,10 +198,7 @@ class WebSocketTestSession:
     def receive_json(self, mode: Literal["text", "binary"] = "text") -> Any:
         message = self.receive()
         self._raise_on_close(message)
-        if mode == "text":
-            text = message["text"]
-        else:
-            text = message["bytes"].decode("utf-8")
+        text = message["text"] if mode == "text" else message["bytes"].decode("utf-8")
         return json.loads(text)
 
 
@@ -454,6 +446,7 @@ class TestClient(httpx.Client):
                 "You should not use the 'timeout' argument with the TestClient. "
                 "See https://github.com/Kludex/starlette/issues/1108 for more information.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         url = self._merge_url(url)
         return super().request(

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -24,14 +24,13 @@ from starlette.exceptions import StarletteDeprecationWarning
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketDisconnect
 
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from typing import Self
+else:  # pragma: no cover
+    from typing_extensions import Self
+
 if TYPE_CHECKING:
     import httpx2 as httpx
-
-    if sys.version_info >= (3, 11):  # pragma: no cover
-        from typing import Self
-    else:  # pragma: no cover
-        from typing_extensions import Self
-
 else:
     try:
         import httpx2 as httpx
@@ -198,7 +197,10 @@ class WebSocketTestSession:
     def receive_json(self, mode: Literal["text", "binary"] = "text") -> Any:
         message = self.receive()
         self._raise_on_close(message)
-        text = message["text"] if mode == "text" else message["bytes"].decode("utf-8")
+        if mode == "text":
+            text = message["text"]
+        else:
+            text = message["bytes"].decode("utf-8")
         return json.loads(text)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
  - Move the `Self` import behind `TYPE_CHECKING` in `testclient`
  - Add clearer warning attribution for `TestClient` timeout deprecation warnings
  - Suppress the underlying `ModuleNotFoundError` chain when `httpx2`/`httpx` is missing
  - Keep `WebSocketTestSession.__enter__` typed as `Self`
  
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
