### PR TITLE
fix: prevent IndexError in URL.replace() on path-only URLs

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -123,7 +123,7 @@ class URL:
                 netloc = self.netloc
                 _, _, hostname = netloc.rpartition("@")
 
-                if hostname[-1] != "]":
+                if hostname and hostname[-1] != "]":
                     hostname = hostname.rsplit(":", 1)[0]
 
             netloc = hostname

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -61,6 +61,12 @@ def test_url() -> None:
     url = URL("http://host:80")
     assert url.replace(username="u") == URL("http://u@host:80")
 
+    # Path-only URLs (no authority) should not raise IndexError
+    url = URL("/path")
+    assert url.replace(port=8080) == URL("//:8080/path")
+    assert url.replace(username="u") == URL("//u@/path")
+    assert url.replace(hostname="example.com") == URL("//example.com/path")
+
 
 def test_url_query_params() -> None:
     u = URL("https://example.org/path/?page=3")


### PR DESCRIPTION
Fixes #3317

# Summary

`URL.replace()` raises `IndexError` when updating authority-related components on path-only URLs such as `/path`.

This happens because the hostname derived from an empty `netloc` is an empty string, and `hostname[-1]` is accessed unconditionally.

Add a guard for empty hostnames before checking the last character, and add regression tests covering path-only URLs.

# Checklist

* [x] I understand that this PR may be closed in case there was no previous discussion.
* [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
* [ ] I've updated the documentation accordingly.
