### PR TITLE
Enforce `max_fields` and `max_part_size` in `FormParser`

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -55,10 +55,19 @@ class MultiPartException(Exception):
 
 
 class FormParser:
-    def __init__(self, headers: Headers, stream: AsyncGenerator[bytes, None]) -> None:
+    def __init__(
+        self,
+        headers: Headers,
+        stream: AsyncGenerator[bytes, None],
+        *,
+        max_fields: int | float = 1000,
+        max_part_size: int = 1024 * 1024,  # 1MB
+    ) -> None:
         assert multipart is not None, "The `python-multipart` library must be installed to use form parsing."
         self.headers = headers
         self.stream = stream
+        self.max_fields = max_fields
+        self.max_part_size = max_part_size
         self.messages: list[tuple[FormMessage, bytes]] = []
 
     def on_field_start(self) -> None:
@@ -97,6 +106,7 @@ class FormParser:
         field_value = bytearray()
 
         items: list[tuple[str, str | UploadFile]] = []
+        field_count = 0
 
         # Feed the parser with data from the request.
         async for chunk in self.stream:
@@ -111,10 +121,17 @@ class FormParser:
                     field_name = bytearray()
                     field_value = bytearray()
                 elif message_type == FormMessage.FIELD_NAME:
+                    if len(field_name) + len(field_value) + len(message_bytes) > self.max_part_size:
+                        raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
                     field_name.extend(message_bytes)
                 elif message_type == FormMessage.FIELD_DATA:
+                    if len(field_name) + len(field_value) + len(message_bytes) > self.max_part_size:
+                        raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
                     field_value.extend(message_bytes)
                 elif message_type == FormMessage.FIELD_END:
+                    field_count += 1
+                    if field_count > self.max_fields:
+                        raise MultiPartException(f"Too many fields. Maximum number of fields is {self.max_fields}.")
                     name = unquote_plus(field_name.decode("latin-1"))
                     value = unquote_plus(field_value.decode("latin-1"))
                     items.append((name, value))

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -294,8 +294,18 @@ class Request(HTTPConnection[StateT]):
                         raise HTTPException(status_code=400, detail=exc.message)
                     raise exc
             elif content_type == b"application/x-www-form-urlencoded":
-                form_parser = FormParser(self.headers, self.stream())
-                self._form = await form_parser.parse()
+                try:
+                    form_parser = FormParser(
+                        self.headers,
+                        self.stream(),
+                        max_fields=max_fields,
+                        max_part_size=max_part_size,
+                    )
+                    self._form = await form_parser.parse()
+                except MultiPartException as exc:
+                    if "app" in self.scope:
+                        raise HTTPException(status_code=400, detail=exc.message)
+                    raise exc
             else:
                 self._form = FormData()
         return self._form

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -465,6 +465,130 @@ def test_multipart_multi_field_app_reads_body(tmpdir: Path, test_client_factory:
     assert response.json() == {"some": "data", "second": "key pair"}
 
 
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (app, pytest.raises(MultiPartException)),
+        (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
+    ],
+)
+def test_urlencoded_too_many_fields_raise(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    data = "&".join(f"N{i}=" for i in range(1001))
+    with expectation:
+        res = client.post(
+            "/",
+            content=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert res.status_code == 400
+        assert res.text == "Too many fields. Maximum number of fields is 1000."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (app, pytest.raises(MultiPartException)),
+        (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
+    ],
+)
+def test_urlencoded_field_exceeds_max_part_size_raise(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    data = "field=" + "x" * (1024 * 1024 + 1)
+    with expectation:
+        res = client.post(
+            "/",
+            content=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert res.status_code == 400
+        assert res.text == "Field exceeded maximum size of 1024KB."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (app, pytest.raises(MultiPartException)),
+        (Starlette(routes=[Mount("/", app=app)]), does_not_raise()),
+    ],
+)
+def test_urlencoded_field_name_exceeds_max_part_size_raise(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    data = "x" * (1024 * 1024 + 1) + "=value"
+    with expectation:
+        res = client.post(
+            "/",
+            content=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert res.status_code == 400
+        assert res.text == "Field exceeded maximum size of 1024KB."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (make_app_max_parts(max_fields=1), pytest.raises(MultiPartException)),
+        (
+            Starlette(routes=[Mount("/", app=make_app_max_parts(max_fields=1))]),
+            does_not_raise(),
+        ),
+    ],
+)
+def test_urlencoded_max_fields_is_customizable(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    with expectation:
+        res = client.post(
+            "/",
+            content="a=1&b=2",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert res.status_code == 400
+        assert res.text == "Too many fields. Maximum number of fields is 1."
+
+
+@pytest.mark.parametrize(
+    "app,expectation",
+    [
+        (make_app_max_parts(max_part_size=1024 * 10), pytest.raises(MultiPartException)),
+        (
+            Starlette(routes=[Mount("/", app=make_app_max_parts(max_part_size=1024 * 10))]),
+            does_not_raise(),
+        ),
+    ],
+)
+def test_urlencoded_max_part_size_is_customizable(
+    app: ASGIApp,
+    expectation: AbstractContextManager[Exception],
+    test_client_factory: TestClientFactory,
+) -> None:
+    client = test_client_factory(app)
+    with expectation:
+        res = client.post(
+            "/",
+            content="field=" + "x" * (1024 * 10 + 1),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert res.status_code == 400
+        assert res.text == "Field exceeded maximum size of 10KB."
+
+
 def test_user_safe_decode_helper() -> None:
     result = _user_safe_decode(b"\xc4\x99\xc5\xbc\xc4\x87", "utf-8")
     assert result == "ężć"


### PR DESCRIPTION
`request.form()` accepts `max_fields` and `max_part_size`, but these were only forwarded to `MultiPartParser`. For `application/x-www-form-urlencoded` bodies, `FormParser` was constructed without them and had no field-count or field-size checks, so the limits had no effect.

This forwards both limits to `FormParser` and enforces them while parsing, raising `MultiPartException` (returned as `400` inside an app) when a body exceeds them. Defaults match `MultiPartParser`: `max_fields=1000`, `max_part_size=1MB`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

