### PR TITLE
Enforce `FormParser` limits in parser callbacks

### DIFF
--- a/starlette/formparsers.py
+++ b/starlette/formparsers.py
@@ -69,20 +69,32 @@ class FormParser:
         self.max_fields = max_fields
         self.max_part_size = max_part_size
         self.messages: list[tuple[FormMessage, bytes]] = []
+        self._current_field_size = 0
+        self._current_fields = 0
 
     def on_field_start(self) -> None:
+        self._current_field_size = 0
         message = (FormMessage.FIELD_START, b"")
         self.messages.append(message)
 
     def on_field_name(self, data: bytes, start: int, end: int) -> None:
+        self._current_field_size += end - start
+        if self._current_field_size > self.max_part_size:
+            raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
         message = (FormMessage.FIELD_NAME, data[start:end])
         self.messages.append(message)
 
     def on_field_data(self, data: bytes, start: int, end: int) -> None:
+        self._current_field_size += end - start
+        if self._current_field_size > self.max_part_size:
+            raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
         message = (FormMessage.FIELD_DATA, data[start:end])
         self.messages.append(message)
 
     def on_field_end(self) -> None:
+        self._current_fields += 1
+        if self._current_fields > self.max_fields:
+            raise MultiPartException(f"Too many fields. Maximum number of fields is {self.max_fields}.")
         message = (FormMessage.FIELD_END, b"")
         self.messages.append(message)
 
@@ -106,7 +118,6 @@ class FormParser:
         field_value = bytearray()
 
         items: list[tuple[str, str | UploadFile]] = []
-        field_count = 0
 
         # Feed the parser with data from the request.
         async for chunk in self.stream:
@@ -121,17 +132,10 @@ class FormParser:
                     field_name = bytearray()
                     field_value = bytearray()
                 elif message_type == FormMessage.FIELD_NAME:
-                    if len(field_name) + len(field_value) + len(message_bytes) > self.max_part_size:
-                        raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
                     field_name.extend(message_bytes)
                 elif message_type == FormMessage.FIELD_DATA:
-                    if len(field_name) + len(field_value) + len(message_bytes) > self.max_part_size:
-                        raise MultiPartException(f"Field exceeded maximum size of {int(self.max_part_size / 1024)}KB.")
                     field_value.extend(message_bytes)
                 elif message_type == FormMessage.FIELD_END:
-                    field_count += 1
-                    if field_count > self.max_fields:
-                        raise MultiPartException(f"Too many fields. Maximum number of fields is {self.max_fields}.")
                     name = unquote_plus(field_name.decode("latin-1"))
                     value = unquote_plus(field_value.decode("latin-1"))
                     items.append((name, value))

--- a/tests/test_formparsers.py
+++ b/tests/test_formparsers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import threading
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from io import BytesIO
 from pathlib import Path
@@ -13,8 +13,8 @@ from unittest import mock
 import pytest
 
 from starlette.applications import Starlette
-from starlette.datastructures import UploadFile
-from starlette.formparsers import MultiPartException, MultiPartParser, _user_safe_decode
+from starlette.datastructures import Headers, UploadFile
+from starlette.formparsers import FormParser, MultiPartException, MultiPartParser, _user_safe_decode
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount
@@ -587,6 +587,30 @@ def test_urlencoded_max_part_size_is_customizable(
         )
         assert res.status_code == 400
         assert res.text == "Field exceeded maximum size of 10KB."
+
+
+@pytest.mark.anyio
+async def test_urlencoded_limits_stop_parsing_within_a_single_chunk() -> None:
+    async def single_chunk(body: bytes) -> AsyncGenerator[bytes, None]:
+        yield body
+
+    headers = Headers({"content-type": "application/x-www-form-urlencoded"})
+
+    too_many = "&".join(f"f{i}=" for i in range(100_000)).encode()
+    stream = single_chunk(too_many)
+    parser = FormParser(headers, stream, max_fields=10)
+    with pytest.raises(MultiPartException, match="Too many fields"):
+        await parser.parse()
+    await stream.aclose()
+    assert parser._current_fields == 11
+
+    too_big = ("field=" + "x" * (1024 * 1024 * 50)).encode()
+    stream = single_chunk(too_big)
+    parser = FormParser(headers, stream, max_part_size=1024)
+    with pytest.raises(MultiPartException, match="Field exceeded maximum size"):
+        await parser.parse()
+    await stream.aclose()
+    assert sum(len(data) for _, data in parser.messages) <= 1024
 
 
 def test_user_safe_decode_helper() -> None:


### PR DESCRIPTION
Follow-up to #3329. The `max_fields` and `max_part_size` checks ran while draining buffered messages, after `QuerystringParser.write()` had already tokenized the whole chunk. When a `application/x-www-form-urlencoded` body arrives as a single chunk (e.g. via the test client, or after `request.body()` has cached it), the parser tokenizes and buffers every field before the drain loop reaches the limit check.

This moves the count and size checks into the `on_field_*` callbacks, which run during `write()`, so parsing stops as soon as a limit is crossed regardless of how the body is chunked. Behaviour and error messages are unchanged; only the point at which parsing aborts moves earlier.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

