### PR TITLE
Allow has_required_scope to accept at least one scope from the list

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -15,17 +15,24 @@ from starlette.websockets import WebSocket
 _P = ParamSpec("_P")
 
 
-def has_required_scope(conn: HTTPConnection, scopes: Sequence[str]) -> bool:
-    for scope in scopes:
-        if scope not in conn.auth.scopes:
-            return False
-    return True
+def has_required_scope(conn: HTTPConnection, scopes: Sequence[str], all_scopes: bool) -> bool:
+    if all_scopes:
+        for scope in scopes:
+            if scope not in conn.auth.scopes:
+                return False
+        return True
+    else:
+        for scope in scopes:
+            if scope in conn.auth.scopes:
+                return True
+        return False
 
 
 def requires(
     scopes: str | Sequence[str],
     status_code: int = 403,
     redirect: str | None = None,
+    all_scopes: bool = True
 ) -> Callable[[Callable[_P, Any]], Callable[_P, Any]]:
     scopes_list = [scopes] if isinstance(scopes, str) else list(scopes)
 
@@ -50,7 +57,7 @@ def requires(
                     f" not '{type(websocket).__name__}'"
                 )
 
-                if not has_required_scope(websocket, scopes_list):
+                if not has_required_scope(websocket, scopes_list, all_scopes):
                     await websocket.close()
                 else:
                     await func(*args, **kwargs)
@@ -66,7 +73,7 @@ def requires(
                     f"Parameter with name 'request' is required to be of type 'Request' not '{type(request).__name__}'"
                 )
 
-                if not has_required_scope(request, scopes_list):
+                if not has_required_scope(request, scopes_list, all_scopes):
                     if redirect is not None:
                         orig_request_qparam = urlencode({"next": str(request.url)})
                         next_url = f"{request.url_for(redirect)}?{orig_request_qparam}"
@@ -85,7 +92,7 @@ def requires(
                     f"Parameter with name 'request' is required to be of type 'Request' not '{type(request).__name__}'"
                 )
 
-                if not has_required_scope(request, scopes_list):
+                if not has_required_scope(request, scopes_list, all_scopes):
                     if redirect is not None:
                         orig_request_qparam = urlencode({"next": str(request.url)})
                         next_url = f"{request.url_for(redirect)}?{orig_request_qparam}"

--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -15,7 +15,11 @@ from starlette.websockets import WebSocket
 _P = ParamSpec("_P")
 
 
-def has_required_scope(conn: HTTPConnection, scopes: Sequence[str], all_scopes: bool) -> bool:
+def has_required_scope(
+    conn: HTTPConnection, 
+    scopes: Sequence[str], 
+    all_scopes: bool = True
+) -> bool:
     if all_scopes:
         for scope in scopes:
             if scope not in conn.auth.scopes:


### PR DESCRIPTION
<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

I've been developing an app where an endpoint can be used by users with different authorization scopes. The default `requires` decorator checks if the user has all of the scopes in the list.

I suggest adding a new parameter `all_scopes` to `has_required_scope` that will modify its behavior and allow a client with at least one of the scopes to use the endpoint. 

This change will take effect only when the developer explicitly defines it, so the default behavior remains unchanged.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

