### PR TITLE
break exception context cycle from BaseExceptionGroup in middleware

### DIFF
--- a/starlette/_utils.py
+++ b/starlette/_utils.py
@@ -89,8 +89,17 @@ async def create_collapsing_task_group() -> AsyncGenerator[anyio.abc.TaskGroup, 
             raise
 
         exc = excs.exceptions[0]
-        context = None if exc.__suppress_context__ else exc.__context__
-        raise exc from exc.__cause__ or context
+        cause = exc.__cause__
+        if cause is None and not exc.__suppress_context__:
+            cause = exc.__context__
+            exc.__suppress_context__ = True
+    else:
+        return
+
+    if cause is not None:
+        raise exc from cause
+    else:
+        raise exc from None
 
 
 def get_route_path(scope: Scope) -> str:

--- a/starlette/middleware/base.py
+++ b/starlette/middleware/base.py
@@ -157,15 +157,16 @@ class BaseHTTPMiddleware:
                     nonlocal exception_already_raised
                     exception_already_raised = True
                     # Prevent `anyio.EndOfStream` from polluting app exception context.
-                    # If both cause and context are None then the context is suppressed
-                    # and `anyio.EndOfStream` is not present in the exception traceback.
-                    # If exception cause is not None then it is propagated with
-                    # reraising here.
-                    # If exception has no cause but has context set then the context is
-                    # propagated as a cause with the reraise. This is necessary in order
-                    # to prevent `anyio.EndOfStream` from polluting the exception
-                    # context.
-                    raise app_exc from app_exc.__cause__ or app_exc.__context__
+                    # If cause is not None it is propagated with reraising here.
+                    # If cause is None but context is set (and not suppressed), the
+                    # context is promoted to cause. This is necessary in order to
+                    # prevent `anyio.EndOfStream` from polluting the exception context.
+                    # If both are None / suppressed, raise with `from None` to suppress
+                    # `anyio.EndOfStream` from appearing in the traceback.
+                    cause = app_exc.__cause__
+                    if cause is None and not app_exc.__suppress_context__:
+                        cause = app_exc.__context__
+                    raise app_exc from cause
                 raise RuntimeError("No response returned.")
 
             assert message["type"] == "http.response.start"


### PR DESCRIPTION
# Summary

When `BaseHTTPMiddleware` catches a route exception, anyio wraps it in a `BaseExceptionGroup`. `create_collapsing_task_group` extracts the single exception and re-raises it — but does so inside the `except`  ذbock.
Python implicitly sets `exc.__context__` to the caught BaseExceptionGroup which contains `exc` itself, creating a reference cycle:
exc.__context__ → BaseExceptionGroup → BaseExceptionGroup.exceptions[0] → exc

Traceback formatters (e.g. Rich) following the `__context__` chain hit infinite recursion when middleware is present.

Fix by raising outside the `except` block so Python does not overwrite `__context__` with the BaseExceptionGroup. Also add the missing `__suppress_context__` guard in `call_next` so suppressed contexts are not incorrectly promoted to cause.

please see discussion: https://github.com/Kludex/starlette/discussions/2942

# Checklist

- [ x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ x ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ x ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

