### PR TITLE
docs: correct GZipMiddleware compresslevel range to 0-9

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -240,7 +240,7 @@ app = Starlette(routes=routes, middleware=middleware)
 The following arguments are supported:
 
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
-* `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
+* `compresslevel` - Used during GZip compression. It is an integer ranging from 0 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 
 The middleware won't GZip responses that already have either a `Content-Encoding` set, to prevent them from
 being encoded twice, or a `Content-Type` set to `text/event-stream`, to avoid compressing server-sent events.


### PR DESCRIPTION
The GZip middleware docs say `compresslevel` is "an integer ranging from 1 to 9". `GZipMiddleware` passes the value straight into `gzip.GzipFile(..., compresslevel=compresslevel)`, which accepts 0 through 9, where 0 means no compression. So 0 is a valid level the current docs exclude.

This updates the range to 0 to 9. Docs-only change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

