### PR TITLE
ServerErrorMiddleware reimplemented using TraceRite.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=3.6.2,<5",
+    "tracerite>=2.3.1",
     "typing_extensions>=4.10.0; python_version < '3.13'",
 ]
 

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -96,16 +96,9 @@ class ServerErrorMiddleware:
         summary = build_chain_header(chain)
         doc = Document(summary, lang="en")
         font_stack = (
-            "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', "
-            "Roboto, 'Helvetica Neue', Arial, sans-serif"
+            "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
         )
-        doc.style(
-            "body {"
-            f"    font-family: {font_stack};"
-            "    line-height: 1.4;"
-            "    margin: 1.5rem;"
-            "}"
-        )
+        doc.style(f"body {{    font-family: {font_stack};    line-height: 1.4;    margin: 1.5rem;}}")
         doc.h1("500 Server Error")
         doc.p(
             "This page is shown for your guidance because the application is "

--- a/starlette/middleware/errors.py
+++ b/starlette/middleware/errors.py
@@ -1,127 +1,19 @@
 from __future__ import annotations
 
-import html
-import inspect
-import sys
-import traceback
+import io
+from typing import Any
+
+import tracerite  # type: ignore[import-untyped]
+from html5tagger import Document  # type: ignore[import-untyped]
+from tracerite.html import html_traceback  # type: ignore[import-untyped]
+from tracerite.trace import build_chain_header  # type: ignore[import-untyped]
+from tracerite.tty import tty_traceback  # type: ignore[import-untyped]
 
 from starlette._utils import is_async_callable
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, PlainTextResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 from starlette.types import ASGIApp, ExceptionHandler, Message, Receive, Scope, Send
-
-STYLES = """
-p {
-    color: #211c1c;
-}
-.traceback-container {
-    border: 1px solid #038BB8;
-}
-.traceback-title {
-    background-color: #038BB8;
-    color: lemonchiffon;
-    padding: 12px;
-    font-size: 20px;
-    margin-top: 0px;
-}
-.frame-line {
-    padding-left: 10px;
-    font-family: monospace;
-}
-.frame-filename {
-    font-family: monospace;
-}
-.center-line {
-    background-color: #038BB8;
-    color: #f9f6e1;
-    padding: 5px 0px 5px 5px;
-}
-.lineno {
-    margin-right: 5px;
-}
-.frame-title {
-    font-weight: unset;
-    padding: 10px 10px 10px 10px;
-    background-color: #E4F4FD;
-    margin-right: 10px;
-    color: #191f21;
-    font-size: 17px;
-    border: 1px solid #c7dce8;
-}
-.collapse-btn {
-    float: right;
-    padding: 0px 5px 1px 5px;
-    border: solid 1px #96aebb;
-    cursor: pointer;
-}
-.collapsed {
-  display: none;
-}
-.source-code {
-  font-family: courier;
-  font-size: small;
-  padding-bottom: 10px;
-}
-"""
-
-JS = """
-<script type="text/javascript">
-    function collapse(element){
-        const frameId = element.getAttribute("data-frame-id");
-        const frame = document.getElementById(frameId);
-
-        if (frame.classList.contains("collapsed")){
-            element.innerHTML = "&#8210;";
-            frame.classList.remove("collapsed");
-        } else {
-            element.innerHTML = "+";
-            frame.classList.add("collapsed");
-        }
-    }
-</script>
-"""
-
-TEMPLATE = """
-<html>
-    <head>
-        <style type='text/css'>
-            {styles}
-        </style>
-        <title>Starlette Debugger</title>
-    </head>
-    <body>
-        <h1>500 Server Error</h1>
-        <h2>{error}</h2>
-        <div class="traceback-container">
-            <p class="traceback-title">Traceback</p>
-            <div>{exc_html}</div>
-        </div>
-        {js}
-    </body>
-</html>
-"""
-
-FRAME_TEMPLATE = """
-<div>
-    <p class="frame-title">File <span class="frame-filename">{frame_filename}</span>,
-    line <i>{frame_lineno}</i>,
-    in <b>{frame_name}</b>
-    <span class="collapse-btn" data-frame-id="{frame_filename}-{frame_lineno}" onclick="collapse(this)">{collapse_button}</span>
-    </p>
-    <div id="{frame_filename}-{frame_lineno}" class="source-code {collapsed}">{code_context}</div>
-</div>
-"""  # noqa: E501
-
-LINE = """
-<p><span class="frame-line">
-<span class="lineno">{lineno}.</span> {line}</span></p>
-"""
-
-CENTER_LINE = """
-<p class="center-line"><span class="frame-line center-line">
-<span class="lineno">{lineno}.</span> {line}</span></p>
-"""
 
 
 class ServerErrorMiddleware:
@@ -141,10 +33,12 @@ class ServerErrorMiddleware:
         app: ASGIApp,
         handler: ExceptionHandler | None = None,
         debug: bool = False,
+        json: bool = False,
     ) -> None:
         self.app = app
         self.handler = handler
         self.debug = debug
+        self.json = json
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -185,73 +79,63 @@ class ServerErrorMiddleware:
             # to optionally raise the error within the test case.
             raise exc
 
-    def format_line(self, index: int, line: str, frame_lineno: int, frame_index: int) -> str:
-        values = {
-            # HTML escape - line could contain < or >
-            "line": html.escape(line).replace(" ", "&nbsp"),
-            "lineno": (frame_lineno - frame_index) + index,
-        }
+    def generate_html(
+        self,
+        exc: Exception,
+        limit: int = 7,
+        request: Request | None = None,
+    ) -> str:
+        """
+        Render an HTML traceback page for the given exception.
 
-        if index != frame_index:
-            return LINE.format(**values)
-        return CENTER_LINE.format(**values)
-
-    def generate_frame_html(self, frame: inspect.FrameInfo, is_collapsed: bool) -> str:
-        code_context = "".join(
-            self.format_line(
-                index,
-                line,
-                frame.lineno,
-                frame.index,  # type: ignore[arg-type]
-            )
-            for index, line in enumerate(frame.code_context or [])
+        The ``limit`` parameter is retained for backwards compatibility but is
+        no longer honoured; TraceRite renders the full traceback.
+        """
+        del limit  # TraceRite does not support frame limiting.
+        chain = tracerite.extract_chain(exc)
+        summary = build_chain_header(chain)
+        doc = Document(summary, lang="en")
+        font_stack = (
+            "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', "
+            "Roboto, 'Helvetica Neue', Arial, sans-serif"
         )
-
-        values = {
-            # HTML escape - filename could contain < or >, especially if it's a virtual
-            # file e.g. <stdin> in the REPL
-            "frame_filename": html.escape(frame.filename),
-            "frame_lineno": frame.lineno,
-            # HTML escape - if you try very hard it's possible to name a function with <
-            # or >
-            "frame_name": html.escape(frame.function),
-            "code_context": code_context,
-            "collapsed": "collapsed" if is_collapsed else "",
-            "collapse_button": "+" if is_collapsed else "&#8210;",
-        }
-        return FRAME_TEMPLATE.format(**values)
-
-    def generate_html(self, exc: Exception, limit: int = 7) -> str:
-        traceback_obj = traceback.TracebackException.from_exception(exc, capture_locals=True)
-
-        exc_html = ""
-        is_collapsed = False
-        exc_traceback = exc.__traceback__
-        if exc_traceback is not None:
-            frames = inspect.getinnerframes(exc_traceback, limit)
-            for frame in reversed(frames):
-                exc_html += self.generate_frame_html(frame, is_collapsed)
-                is_collapsed = True
-
-        if sys.version_info >= (3, 13):  # pragma: no cover
-            exc_type_str = traceback_obj.exc_type_str
-        else:  # pragma: no cover
-            exc_type_str = traceback_obj.exc_type.__name__
-
-        # escape error class and text
-        error = f"{html.escape(exc_type_str)}: {html.escape(str(traceback_obj))}"
-
-        return TEMPLATE.format(styles=STYLES, js=JS, error=error, exc_html=exc_html)
+        doc.style(
+            "body {"
+            f"    font-family: {font_stack};"
+            "    line-height: 1.4;"
+            "    margin: 1.5rem;"
+            "}"
+        )
+        doc.h1("500 Server Error")
+        doc.p(
+            "This page is shown for your guidance because the application is "
+            "running in debug mode and has crashed handling this request."
+        )
+        doc(html_traceback(exc=exc, chain=chain, include_js_css=True))
+        return str(doc)
 
     def generate_plain_text(self, exc: Exception) -> str:
-        return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        """Render a plain-text traceback for the given exception."""
+        buffer = io.StringIO()
+        tty_traceback(exc, file=buffer)
+        return buffer.getvalue()
+
+    def generate_json(self, exc: Exception) -> dict[str, Any]:
+        """Render a structured JSON traceback for the given exception."""
+        chain = tracerite.extract_chain(exc)
+        return {
+            "detail": build_chain_header(chain),
+            "traceback": chain,
+        }
 
     def debug_response(self, request: Request, exc: Exception) -> Response:
         accept = request.headers.get("accept", "")
 
         if "text/html" in accept:
-            content = self.generate_html(exc)
+            content = self.generate_html(exc, request=request)
             return HTMLResponse(content, status_code=500)
+        if self.json and "application/json" in accept:
+            return JSONResponse(self.generate_json(exc), status_code=500)
         content = self.generate_plain_text(exc)
         return PlainTextResponse(content, status_code=500)
 

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -25,6 +25,8 @@ from starlette.responses import PlainTextResponse, RedirectResponse, Response
 from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketClose
 
+__tracebackhide__ = "until"
+
 
 class NoMatchFound(Exception):
     """

--- a/tests/middleware/test_errors.py
+++ b/tests/middleware/test_errors.py
@@ -52,6 +52,32 @@ def test_debug_html(test_client_factory: TestClientFactory) -> None:
     assert "RuntimeError" in response.text
 
 
+def test_debug_json(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        raise RuntimeError("Something went wrong")
+
+    app = ServerErrorMiddleware(app, debug=True, json=True)
+    client = test_client_factory(app, raise_server_exceptions=False)
+    response = client.get("/", headers={"Accept": "application/json"})
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    data = response.json()
+    assert data["detail"] == "⚠️  Uncaught RuntimeError"
+    assert data["traceback"]
+
+
+def test_debug_json_disabled_by_default(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        raise RuntimeError("Something went wrong")
+
+    app = ServerErrorMiddleware(app, debug=True)
+    client = test_client_factory(app, raise_server_exceptions=False)
+    response = client.get("/", headers={"Accept": "application/json"})
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "RuntimeError: Something went wrong" in response.text
+
+
 def test_debug_after_response_sent(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         response = Response(b"", status_code=204)

--- a/uv.lock
+++ b/uv.lock
@@ -495,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html5tagger"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/02/2ae5f46d517a2c1d4a17f2b1e4834c2c7cc0fb3a69c92389172fa16ab389/html5tagger-1.3.0.tar.gz", hash = "sha256:84fa3dfb49e5c83b79bbd856ab7b1de8e2311c3bb46a8be925f119e3880a8da9", size = 14196, upload-time = "2023-03-28T05:59:34.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/12/2f5d43ee912ea14a6baba4b3db6d309b02d932e3b7074c3339b4aded98ff/html5tagger-1.3.0-py3-none-any.whl", hash = "sha256:ce14313515edffec8ed8a36c5890d023922641171b4e6e5774ad1a74998f5351", size = 10956, upload-time = "2023-03-28T05:59:32.524Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1432,6 +1441,7 @@ name = "starlette"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "tracerite" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 
@@ -1474,6 +1484,7 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'full'" },
     { name = "python-multipart", marker = "extra == 'full'", specifier = ">=0.0.18" },
     { name = "pyyaml", marker = "extra == 'full'" },
+    { name = "tracerite", specifier = ">=2.3.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10.0" },
 ]
 provides-extras = ["full"]
@@ -1550,6 +1561,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tracerite"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "html5tagger" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/b9/89b065c1818e5973c333a33311f823954ff4c7c48440c20b37669c5b752c/tracerite-2.3.1.tar.gz", hash = "sha256:f46ee672d240d500a2331781b09eb33564d473f6ae60cd871ebce6c2413cffa8", size = 61303, upload-time = "2025-12-30T22:51:19.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/62/3f385a67ff3cc91209f107d20bbebdecf7a4e4aba55a43f9f71bddc424a9/tracerite-2.3.1-py3-none-any.whl", hash = "sha256:5f9595ba90f075b58e14a9baf84d8204fec3cdce50029f1c32d757af79d9ccbe", size = 65884, upload-time = "2025-12-30T22:51:18.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

Implemented cleaner traceback rendering with the ServerErrorMiddleware completely rewritten. Maintains compatibility with the old one, but uses the lightweight plain-Python tracerite module to do the formatting.

In addition to HTML and text output, this also offers optional JSON output (disabled by default to maintain earlier functionality and because that might still be preferred especially with curl).

The motivation to this is that [TraceRite](https://github.com/sanic-org/tracerite) makes error messages to the point, short and easy to read with just the relevant information visible. Refer to its page for further information and examples. The module is maintained by Sanic and has been well battle tested.

I left out console pretty exception logging, also supported by the module, to keep the changes minimal. It may be separately loaded if needed.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

