### PR TITLE
Add Request.send_early_hints ASGI extension helper

### DIFF
--- a/docs/server-push.md
+++ b/docs/server-push.md
@@ -34,3 +34,23 @@ routes = [
 
 app = Starlette(routes=routes)
 ```
+
+### `Request.send_early_hints`
+
+Used to send HTTP 103 Early Hints with one or more `Link` header values before
+the final response. If Early Hints are not available this method does nothing.
+
+Signature: `send_early_hints(links)`
+
+* `links` - A string, or iterable of strings, containing `Link` header values.
+
+```python
+from starlette.responses import HTMLResponse
+
+
+async def homepage(request):
+    await request.send_early_hints("</static/style.css>; rel=preload; as=style")
+    return HTMLResponse(
+        '<html><head><link rel="stylesheet" href="/static/style.css"/></head></html>'
+    )
+```

--- a/starlette/requests.py
+++ b/starlette/requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import AsyncGenerator, Iterator, Mapping
+from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
 from http import cookies as http_cookies
 from typing import TYPE_CHECKING, Any, Generic, NoReturn, cast
 
@@ -346,3 +346,13 @@ class Request(HTTPConnection[StateT]):
                 for value in self.headers.getlist(name):
                     raw_headers.append((name.encode("latin-1"), value.encode("latin-1")))
             await self._send({"type": "http.response.push", "path": path, "headers": raw_headers})
+
+    async def send_early_hints(self, links: str | bytes | Iterable[str | bytes]) -> None:
+        if "http.response.early_hint" in self.scope.get("extensions", {}):
+            if isinstance(links, str):
+                raw_links = [links.encode("latin-1")]
+            elif isinstance(links, bytes):
+                raw_links = [links]
+            else:
+                raw_links = [link.encode("latin-1") if isinstance(link, str) else link for link in links]
+            await self._send({"type": "http.response.early_hint", "links": raw_links})

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -564,6 +564,79 @@ def test_request_send_push_promise_without_setting_send(
     assert response.json() == {"json": "Send channel not available"}
 
 
+@pytest.mark.anyio
+async def test_request_send_early_hints() -> None:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "extensions": {"http.response.early_hint": {}},
+    }
+    request = Request(scope, send=send)
+
+    await request.send_early_hints("</style.css>; rel=preload; as=style")
+
+    assert messages == [
+        {
+            "type": "http.response.early_hint",
+            "links": [b"</style.css>; rel=preload; as=style"],
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_multiple_links() -> None:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "extensions": {"http.response.early_hint": {}},
+    }
+    request = Request(scope, send=send)
+
+    await request.send_early_hints(
+        [
+            "</style.css>; rel=preload; as=style",
+            "</script.js>; rel=preload; as=script",
+        ]
+    )
+
+    assert messages == [
+        {
+            "type": "http.response.early_hint",
+            "links": [
+                b"</style.css>; rel=preload; as=style",
+                b"</script.js>; rel=preload; as=script",
+            ],
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_request_send_early_hints_without_extension() -> None:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    scope: Scope = {"type": "http", "method": "GET", "path": "/"}
+    request = Request(scope, send=send)
+
+    await request.send_early_hints("</style.css>; rel=preload; as=style")
+
+    assert messages == []
+
+
 @pytest.mark.parametrize(
     "messages",
     [

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -25,6 +25,11 @@ def test_deprecated_types(constant: str, msg: str) -> None:
         assert msg in str(record.list[0])
 
 
+def test_http_103_early_hints() -> None:
+    status = importlib.import_module("starlette.status")
+    assert status.HTTP_103_EARLY_HINTS == 103
+
+
 def test_unknown_status() -> None:
     with pytest.raises(
         AttributeError,


### PR DESCRIPTION
# Context
This pull request addresses issue #3308 by adding support for HTTP 103 Early Hints in Starlette.

# Solution
We introduce an explicit `Request.send_early_hints` method that will send the ASGI `http.response.early_hint` extension message when supported by the server. This method will allow sending one or more `Link` header values before the final response is returned.

# Scope
- Added `HTTP_103_EARLY_HINTS = 103` in `starlette/status.py`.
- Implemented `async Request.send_early_hints` in `starlette/requests.py`.
- The method encodes string values to bytes and sends an early hints message only if the extension is available.
- Maintained compatibility with existing behavior by ensuring the method does nothing when the extension is not present.
- Introduced unit tests for various scenarios and added assertions in existing tests for validation.
- Updated documentation to reflect new functionality.

# Tests Run
- Added unit tests in `tests/test_requests.py` covering multiple link scenarios.
- Updated `tests/test_status.py` to validate status constants.

# Results
All checks have passed with 986 tests successfully completed. The diff includes 179 lines.

# Risks
No significant risks identified as the implementation maintains backward compatibility with existing behavior.

# Related Issue
- Resolves #3308

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

