### PR TITLE
docs: fix default package static directory name

### DIFF
--- a/docs/staticfiles.md
+++ b/docs/staticfiles.md
@@ -49,7 +49,7 @@ routes=[
 app = Starlette(routes=routes)
 ```
 
-By default `StaticFiles` will look for a `static` directory in each package,
+By default `StaticFiles` will look for a `statics` directory in each package,
 you can change the default directory by specifying a tuple of strings.
 
 ```python


### PR DESCRIPTION
# Summary

## Just a small typo :)

 Docs said the default package static dir is `static`, but the code uses `statics`:
https://github.com/Kludex/starlette/blob/de970d7b3facb853eb7ad077decbf3d94f2aab6c/starlette/staticfiles.py#L75

...Unless I misunderstood something.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

