### PR TITLE
Switches authentication scopes to utilize sets

### DIFF
--- a/starlette/authentication.py
+++ b/starlette/authentication.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable
 from typing import Any, ParamSpec
 from urllib.parse import urlencode
 
@@ -15,19 +15,18 @@ from starlette.websockets import WebSocket
 _P = ParamSpec("_P")
 
 
-def has_required_scope(conn: HTTPConnection, scopes: Sequence[str]) -> bool:
-    for scope in scopes:
-        if scope not in conn.auth.scopes:
-            return False
-    return True
+def has_required_scope(conn: HTTPConnection, scopes: Iterable[str]) -> bool:
+    if not isinstance(scopes, set):
+        scopes = set(scopes)
+    return scopes.issubset(conn.auth.scopes)
 
 
 def requires(
-    scopes: str | Sequence[str],
+    scopes: str | Iterable[str],
     status_code: int = 403,
     redirect: str | None = None,
 ) -> Callable[[Callable[_P, Any]], Callable[_P, Any]]:
-    scopes_list = [scopes] if isinstance(scopes, str) else list(scopes)
+    scopes_list = {scopes} if isinstance(scopes, str) else set(scopes)
 
     def decorator(
         func: Callable[_P, Any],
@@ -108,8 +107,8 @@ class AuthenticationBackend:
 
 
 class AuthCredentials:
-    def __init__(self, scopes: Sequence[str] | None = None):
-        self.scopes = [] if scopes is None else list(scopes)
+    def __init__(self, scopes: Iterable[str] | None = None):
+        self.scopes = set() if scopes is None else set(scopes)
 
 
 class BaseUser:


### PR DESCRIPTION


<!-- Thanks for contributing to Starlette! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Changes the storage collection used for storing the required scopes of the endpoint and the built-in AuthCredentials class. Sets often have better containment evaluation complexity than lists. This change should improve the average time complexity needed for evaluating the user's scopes against the endpoint as either the endpoint or the user's scopes increase in size.

- Tests remain unchanged
- User facing functionality remains unchanged

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

