### PR TITLE
fix(routing): normalize trailing slashes on mounted routes

### DIFF
--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -379,6 +379,16 @@ class Mount(BaseRoute):
                 self.app = cls(self.app, *args, **kwargs)
         self.name = name
         self.path_regex, self.path_format, self.param_convertors = compile_path(self.path + "/{path:path}")
+        if self.path:
+            # A mount path of `/users` should match both `/users` and `/users/`.
+            # Rewrite the catch-all `path` parameter so that the trailing slash
+            # is optional, while `/usersa` still does not match.
+            path_regex = self.path_regex.pattern
+            path_convertor_regex = self.param_convertors["path"].regex
+            suffix = f"/(?P<path>{path_convertor_regex})$"
+            if path_regex.endswith(suffix):
+                path_regex = path_regex[: -len(suffix)] + f"(?P<path>(?:/.*)?)$"
+                self.path_regex = re.compile(path_regex)
 
     @property
     def routes(self) -> list[BaseRoute]:
@@ -394,8 +404,17 @@ class Mount(BaseRoute):
                 matched_params = match.groupdict()
                 for key, value in matched_params.items():
                     matched_params[key] = self.param_convertors[key].convert(value)
-                remaining_path = "/" + matched_params.pop("path")
-                matched_path = route_path[: -len(remaining_path)]
+                path_value = matched_params.pop("path")
+                if not route_path.endswith("/") and path_value in (None, ""):
+                    # The request path matched the mount point without a trailing
+                    # slash (e.g. `/users`). Route it the same as `/users/` so
+                    # child routes like `Route("/", ...)` resolve correctly.
+                    matched_path = route_path
+                    scope["path"] = scope["path"] + "/"
+                    remaining_path = "/"
+                else:
+                    remaining_path = path_value if path_value else "/"
+                    matched_path = route_path[: -len(remaining_path)]
                 path_params = dict(scope.get("path_params", {}))
                 path_params.update(matched_params)
                 child_scope = {

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -387,7 +387,7 @@ class Mount(BaseRoute):
             path_convertor_regex = self.param_convertors["path"].regex
             suffix = f"/(?P<path>{path_convertor_regex})$"
             if path_regex.endswith(suffix):
-                path_regex = path_regex[: -len(suffix)] + f"(?P<path>(?:/.*)?)$"
+                path_regex = path_regex[: -len(suffix)] + r"(?P<path>(?:/.*)?)$"
                 self.path_regex = re.compile(path_regex)
 
     @property

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -377,10 +377,40 @@ def test_mount_urls(test_client_factory: TestClientFactory) -> None:
     mounted = Router([Mount("/users", ok, name="users")])
     client = test_client_factory(mounted)
     assert client.get("/users").status_code == 200
-    assert client.get("/users").url == "http://testserver/users/"
+    assert client.get("/users").url == "http://testserver/users"
     assert client.get("/users/").status_code == 200
+    assert client.get("/users/").url == "http://testserver/users/"
     assert client.get("/users/a").status_code == 200
     assert client.get("/usersa").status_code == 404
+
+
+def test_mount_trailing_slash_with_child_routes(test_client_factory: TestClientFactory) -> None:
+    mounted = Router(
+        [
+            Mount(
+                "/users",
+                routes=[
+                    Route("/", users, name="users"),
+                    Route("/{username}", user, name="user"),
+                ],
+            )
+        ]
+    )
+    client = test_client_factory(mounted)
+
+    response = client.get("/users")
+    assert response.status_code == 200
+    assert response.url == "http://testserver/users"
+    assert response.text == "All users"
+
+    response = client.get("/users/")
+    assert response.status_code == 200
+    assert response.url == "http://testserver/users/"
+    assert response.text == "All users"
+
+    response = client.get("/users/tom")
+    assert response.status_code == 200
+    assert response.text == "User tom"
 
 
 def test_reverse_mount_urls() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -412,6 +412,10 @@ def test_mount_trailing_slash_with_child_routes(test_client_factory: TestClientF
     assert response.status_code == 200
     assert response.text == "User tom"
 
+    response = client.get("/users/tom/")
+    assert response.status_code == 200
+    assert response.text == "User tom"
+
 
 def test_reverse_mount_urls() -> None:
     mounted = Router([Mount("/users", ok, name="users")])


### PR DESCRIPTION
Fixes #869

`Mount('/users', routes=[Route('/', users), Route('/{username}', user)])` currently only matches when the request path ends with a slash. `GET /users` returns a 307 redirect to `/users/`, and `GET /users/bob/` returns a 307 redirect to `/users/bob`, while a top-level `Route('/', ...)` responds to both `/` and an empty path. This asymmetry between `Route` and `Mount` has been reported repeatedly: external webhook callers that don't follow redirects fail, Ariadne's GraphQL mount is unreachable at `/graphql`, and people have resorted to setting `app.router.redirect_slashes = False` or adding middleware to rewrite the path.

In #823 the maintainer explained that requiring the slash was intentional, because a mount point is meant to be `/path-to-mount/{...}` and `/some-path` should not match `/some-path{...}`. That constraint is still respected here: `/usersa` still 404s.

This change rewrites the catch-all `path` regex that `Mount` builds from `compile_path(self.path + "/{path:path}")` so the trailing slash is optional. When the mount point is hit without a slash, the router appends the slash to `scope["path"]` internally before dispatching to the mounted app, so `Route('/', ...)` resolves directly and `Route('/{username}', ...)` works with or without a trailing slash. The existing `test_mount_urls` assertion is updated to expect `/users` to stay `/users` instead of redirecting to `/users/`, and a new `test_mount_trailing_slash_with_child_routes` covers the child-route cases.

The main trade-off is that `/users` no longer redirects to `/users/`; it now serves the mounted content directly. That removes the 307 pain for mounts but changes behavior for anyone relying on the old redirect. Other `Route` redirects and `redirect_slashes` behavior are unaffected.

Verified by running `pytest tests/test_routing.py`.
