### PR TITLE
docs: fix broken link in TestClient.auth docstring

### DIFF
--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -427,6 +427,10 @@ class TestClient(httpx.Client):
         """
         return self._auth
 
+    @auth.setter
+    def auth(self, auth: httpx._types.AuthTypes) -> None:
+        self._auth = self._build_auth(auth)
+
     @contextlib.contextmanager
     def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
         if self.portal is not None:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -390,7 +390,7 @@ class TestClient(httpx.Client):
         headers: dict[str, str] | None = None,
         follow_redirects: bool = True,
         client: tuple[str, int] = ("testclient", 50000),
-    ) -> None:
+    ) -> None:    
         self.async_backend = _AsyncBackend(backend=backend, backend_options=backend_options or {})
         if _is_asgi3(app):
             asgi_app = app
@@ -417,7 +417,16 @@ class TestClient(httpx.Client):
             follow_redirects=follow_redirects,
             cookies=cookies,
         )
+        
+    @property
+    def auth(self) -> httpx.Auth | None:
+        """
+        Authentication class used when none is passed at the request-level.
 
+        See also [HTTPX Authentication](https://www.python-httpx.org/quickstart/#authentication).
+        """
+        return self._auth
+    
     @contextlib.contextmanager
     def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
         if self.portal is not None:

--- a/starlette/testclient.py
+++ b/starlette/testclient.py
@@ -390,7 +390,7 @@ class TestClient(httpx.Client):
         headers: dict[str, str] | None = None,
         follow_redirects: bool = True,
         client: tuple[str, int] = ("testclient", 50000),
-    ) -> None:    
+    ) -> None:
         self.async_backend = _AsyncBackend(backend=backend, backend_options=backend_options or {})
         if _is_asgi3(app):
             asgi_app = app
@@ -417,7 +417,7 @@ class TestClient(httpx.Client):
             follow_redirects=follow_redirects,
             cookies=cookies,
         )
-        
+
     @property
     def auth(self) -> httpx.Auth | None:
         """
@@ -426,7 +426,7 @@ class TestClient(httpx.Client):
         See also [HTTPX Authentication](https://www.python-httpx.org/quickstart/#authentication).
         """
         return self._auth
-    
+
     @contextlib.contextmanager
     def _portal_factory(self) -> Generator[anyio.abc.BlockingPortal, None, None]:
         if self.portal is not None:


### PR DESCRIPTION
# Summary

Fixed a broken link in `TestClient.auth`'s docstring. The property
currently inherits its docstring from `httpx.Client.auth`, which
contains a relative link that resolves incorrectly when rendered on
downstream docs sites, causing a 404.

This adds an override with a corrected absolute link to HTTPX's docs.

Found via fastapi/fastapi#16061

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

