### PR TITLE
Fix KeyError in GZipMiddleware when the response body key is omitted

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -69,27 +69,27 @@ class IdentityResponder:
                 await self.send(message)
             elif not more_body:
                 # Standard response.
-                body = self.apply_compression(body, more_body=False)
+                compressed_body = self.apply_compression(body, more_body=False)
 
                 headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers.add_vary_header("Accept-Encoding")
-                if body != message["body"]:
+                if compressed_body != body:
                     headers["Content-Encoding"] = self.content_encoding
-                    headers["Content-Length"] = str(len(body))
-                    message["body"] = body
+                    headers["Content-Length"] = str(len(compressed_body))
+                    message["body"] = compressed_body
 
                 await self.send(self.initial_message)
                 await self.send(message)
             else:
                 # Initial body in streaming response.
-                body = self.apply_compression(body, more_body=True)
+                compressed_body = self.apply_compression(body, more_body=True)
 
                 headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers.add_vary_header("Accept-Encoding")
-                if body != message["body"]:
+                if compressed_body != body:
                     headers["Content-Encoding"] = self.content_encoding
                     del headers["Content-Length"]
-                    message["body"] = body
+                    message["body"] = compressed_body
 
                 await self.send(self.initial_message)
                 await self.send(message)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -10,7 +10,7 @@ from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import ContentStream, FileResponse, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
-from starlette.types import Message
+from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -114,6 +114,32 @@ def test_gzip_streaming_response_identity(test_client_factory: TestClientFactory
     assert "Content-Encoding" not in response.headers
     assert response.headers["Vary"] == "Accept-Encoding"
     assert "Content-Length" not in response.headers
+
+
+async def streaming_app_without_body_key(scope: Scope, receive: Receive, send: Send) -> None:
+    """An app that omits the optional `body` key on the first `http.response.body` message."""
+    await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
+    await send({"type": "http.response.body", "more_body": True})
+    await send({"type": "http.response.body", "body": b"x" * 4000, "more_body": False})
+
+
+def test_gzip_streaming_response_without_body_key(test_client_factory: TestClientFactory) -> None:
+    client = test_client_factory(GZipMiddleware(streaming_app_without_body_key))
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.text == "x" * 4000
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert "Content-Length" not in response.headers
+
+
+def test_gzip_streaming_response_identity_without_body_key(test_client_factory: TestClientFactory) -> None:
+    client = test_client_factory(GZipMiddleware(streaming_app_without_body_key))
+    response = client.get("/", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.text == "x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert response.headers["Vary"] == "Accept-Encoding"
 
 
 def test_gzip_ignored_for_responses_with_encoding_set(


### PR DESCRIPTION
### Summary

`GZipMiddleware` raises `KeyError: 'body'` when an ASGI app omits the optional
`body` key on the first `http.response.body` message of a streaming response.

The ASGI HTTP spec defines `body` as optional on Response Body events, defaulting
to `b""`. `IdentityResponder.send_with_compression` already honours that: it reads
the value with `message.get("body", b"")`. Two lines later it compares the
compression result against `message["body"]` instead, and that direct index raises
for a message without the key. Both `GZipResponder` and `IdentityResponder` are
affected, so it fails whether or not the client sends `Accept-Encoding: gzip`.

### Reproduction (on `main`)

```python
from starlette.middleware.gzip import GZipMiddleware
from starlette.testclient import TestClient


async def app(scope, receive, send):
    await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
    await send({"type": "http.response.body", "more_body": True})  # no "body" key
    await send({"type": "http.response.body", "body": b"x" * 4000, "more_body": False})


TestClient(GZipMiddleware(app)).get("/", headers={"accept-encoding": "gzip"})
```

```
  File "starlette/middleware/gzip.py", line 89, in send_with_compression
    if body != message["body"]:
               ~~~~~~~^^^^^^^^
KeyError: 'body'
```

### Fix

Keep the value read with `message.get("body", b"")` and compare the compression
result against it, rather than re-reading the key from the message. Behaviour is
otherwise unchanged: the comparison still detects whether compression altered the
payload, which is what decides the `Content-Encoding` and `Content-Length` headers.

The same pattern is applied to the non-streaming branch, which is reachable the
same way when `minimum_size=0`.

### Verification

- Added `test_gzip_streaming_response_without_body_key` and
  `test_gzip_streaming_response_identity_without_body_key`. Both fail on `main`
  with `KeyError: 'body'` (4 failures across the asyncio and trio backends) and
  pass with this change.
- Full suite: 983 passed, 2 xfailed.
- `ruff format --check`, `ruff check`, `mypy starlette tests`: clean.
- `coverage report --fail-under=100`: 100%.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

