### PR TITLE
Make route matching pluggable with RouteLookup

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -331,3 +331,114 @@ The `endpoint` argument can be one of:
 
 * An async function, which accepts a single `websocket` argument.
 * A class that implements the ASGI interface, such as Starlette's [WebSocketEndpoint](endpoints.md#websocketendpoint).
+
+## Route lookups
+
+By default a `Router` scans its routes in order, calling `matches()` on each one
+until a route matches. That is simple and predictable, but the cost grows with the
+number of routes, and a request that matches nothing pays for the full scan.
+
+A **route lookup** replaces that scan with something faster, such as a trie or a
+native extension, without changing what a match means. The lookup only narrows the
+routes a router has to check. Starlette still calls `BaseRoute.matches()` on every
+candidate, so path parameters, convertors, `Mount`, `Host`, WebSockets, trailing
+slash redirects, `405 Method Not Allowed` and first-registered-wins ordering all
+behave exactly as before.
+
+Install one by assigning a factory:
+
+```python
+from starlette.applications import Starlette
+
+app = Starlette(routes=routes)
+app.route_lookup_factory = SomeRouteLookup
+```
+
+The assignment applies to the whole routing tree: mounted applications, routers
+behind `Host`, nested mounts, and routers mounted later all inherit it, and each
+one compiles its own lookup from its own routes. A nested router that was given a
+lookup of its own keeps it. Assign `None` to go back to the plain linear scan.
+
+### Writing a route lookup
+
+A lookup is any object with a `candidates()` method, and a factory is anything that
+builds one from a sequence of routes:
+
+```python
+from starlette.routing import Route, get_route_path
+
+
+class PrefixRouteLookup:
+    def __init__(self, routes):
+        self.positions = {id(route): index for index, route in enumerate(routes)}
+        self.buckets = {}
+        self.always = []
+        for route in routes:
+            # Exact type check: a `Route` subclass may override `matches()` and
+            # match paths its own `path` does not describe.
+            first = route.path.lstrip("/").split("/")[0] if type(route) is Route else ""
+            if first and "{" not in first:
+                self.buckets.setdefault(first, []).append(route)
+            else:
+                self.always.append(route)
+
+    def candidates(self, scope):
+        first = get_route_path(scope).lstrip("/").split("/")[0]
+        bucket = self.buckets.get(first, [])
+        return sorted(self.always + bucket, key=lambda route: self.positions[id(route)])
+```
+
+Implementations have to honour the following contract, because a route that never
+reaches `matches()` silently becomes unreachable:
+
+* `candidates()` must return a **superset** of the routes whose `matches()` would
+  return `Match.FULL` or `Match.PARTIAL`. Never filter on `scope["method"]`:
+  dropping method mismatches turns a `405 Method Not Allowed` into a `404 Not Found`.
+* Candidates must come back in registration order, without duplicates, and must
+  come from the route table the lookup was built with.
+* Only index a route by its path when you understand its type exactly. Use
+  `type(route) is Route`, not `isinstance()`. Anything else, including `Mount`,
+  `Host` and custom `BaseRoute` implementations, should be treated as an
+  always-candidate.
+* `candidates()` is called at least once per request, and again with a modified
+  scope for the trailing slash redirect check, so it must return a fresh iterable
+  every time and must not cache by scope identity.
+* It must be sync, must not mutate the scope, and must not send or receive ASGI
+  messages.
+* Candidates may be consumed lazily and abandoned as soon as a route matches, so a
+  generator must not hold locks across a yield.
+
+Use `starlette.routing.get_route_path()` to get the path a router matches against.
+It strips `root_path`, which matters for mounted applications.
+
+### Checking a lookup
+
+`StrictRouteLookup` wraps another factory and verifies the contract on every
+request, raising `RouteLookupError` when a candidate is dropped, duplicated,
+reordered, or foreign to the route table:
+
+```python
+from starlette.routing import StrictRouteLookup
+
+app.route_lookup_factory = StrictRouteLookup(PrefixRouteLookup)
+```
+
+It runs the linear scan alongside the lookup, so it is meant for tests, CI and
+staging rather than production.
+
+### Rebuilding
+
+Lookups are compiled from a snapshot of `router.routes`, and rebuilt automatically
+whenever routes are added, removed, replaced or reordered. Mutating a route object
+in place is invisible, so tell the router about it:
+
+```python
+route.path = "/changed"
+app.router.invalidate_route_lookup()
+```
+
+Lookups are compiled during lifespan startup, so a failing lookup surfaces at boot
+instead of on the first request. Applications that never run a lifespan can build
+them explicitly with `app.router.build_route_lookup()`, and
+`app.router.route_lookup` shows the compiled lookup currently in use, or `None`
+when the linear scan is being used.

--- a/starlette/applications.py
+++ b/starlette/applications.py
@@ -9,7 +9,7 @@ from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import BaseRoute, Router
+from starlette.routing import BaseRoute, RouteLookupFactory, Router
 from starlette.types import ASGIApp, ExceptionHandler, Lifespan, Receive, Scope, Send
 
 AppType = TypeVar("AppType", bound="Starlette")
@@ -79,6 +79,24 @@ class Starlette:
     @property
     def routes(self) -> list[BaseRoute]:
         return self.router.routes
+
+    @property
+    def route_lookup_factory(self) -> RouteLookupFactory | None:
+        """The `RouteLookupFactory` used to narrow route matching.
+
+        Assigning applies to the whole routing tree, including mounted
+        sub-applications and routers mounted later:
+
+            app.route_lookup_factory = ffroute.RouteLookup
+
+        See `starlette.routing.RouteLookup` for the contract an implementation has
+        to honour.
+        """
+        return self.router.route_lookup_factory
+
+    @route_lookup_factory.setter
+    def route_lookup_factory(self, factory: RouteLookupFactory | None) -> None:
+        self.router.route_lookup_factory = factory
 
     def url_path_for(self, name: str, /, **path_params: Any) -> URLPath:
         return self.router.url_path_for(name, **path_params)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -7,14 +7,17 @@ import re
 import traceback
 import types
 import warnings
-from collections.abc import Awaitable, Callable, Collection, Generator, Sequence
+from collections.abc import Awaitable, Callable, Collection, Generator, Iterable, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, asynccontextmanager
 from enum import Enum
 from re import Pattern
-from typing import Any, TypeVar
+from typing import Any, Protocol, SupportsIndex, TypeVar
 
 from starlette._exception_handler import wrap_app_handling_exceptions
-from starlette._utils import get_route_path, is_async_callable
+
+# `get_route_path` is part of the public API: route lookup implementations need it to
+# resolve the path a router matches against, with `root_path` stripped.
+from starlette._utils import get_route_path as get_route_path, is_async_callable
 from starlette.concurrency import run_in_threadpool
 from starlette.convertors import CONVERTOR_TYPES, Convertor
 from starlette.datastructures import URL, Headers, URLPath
@@ -563,6 +566,242 @@ class _DefaultLifespan:
         return self
 
 
+class RouteLookup(Protocol):
+    """Narrows the routes a `Router` has to check for an incoming scope.
+
+    A route lookup never decides a match: `Router` still calls `BaseRoute.matches()`
+    on every candidate, so path params, method handling, mounts, hosts and
+    registration order stay Starlette's business. The lookup only answers "which
+    routes could possibly match?", which lets an implementation replace the linear
+    scan with a trie, a radix tree, a native extension, or anything else.
+
+    Implementations must honour the following contract. Breaking it means routes
+    silently stop being reachable:
+
+    * `candidates()` must return a **superset** of the routes whose `matches()`
+      would return `Match.FULL` **or** `Match.PARTIAL`. Never filter on
+      `scope["method"]` or `scope["type"]`: dropping method mismatches turns a
+      `405 Method Not Allowed` into a `404 Not Found`.
+    * Candidates must be yielded in registration order, without duplicates.
+    * Only routes from the `routes` sequence the lookup was built with may be
+      returned.
+    * A route may only be indexed by its path when its type is understood
+      exactly. Use `type(route) is Route`, not `isinstance()`: a subclass may
+      override `matches()` and match paths its own `path` does not describe.
+      Anything else must be treated as an always-candidate.
+    * `candidates()` is called at least once per request, and again with a
+      modified scope for the trailing-slash redirect check, so it must not cache
+      results by scope identity, and must return a fresh iterable every call.
+    * It must be sync, must not mutate the scope, and must not receive or send
+      ASGI messages.
+    * Candidates may be consumed lazily and abandoned as soon as a route matches,
+      so a generator must not hold locks or other resources across a yield.
+
+    Use `starlette.routing.StrictRouteLookup` in tests to verify the contract.
+    """
+
+    def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]: ...
+
+
+# Builds a `RouteLookup` for one router's route table. Receives an immutable
+# snapshot of the routes, so the lookup can compile them once, up front.
+RouteLookupFactory = Callable[[Sequence[BaseRoute]], RouteLookup]
+
+
+class RouteLookupError(RuntimeError):
+    """Raised by `StrictRouteLookup` when a `RouteLookup` breaks its contract."""
+
+
+class StrictRouteLookup:
+    """A `RouteLookupFactory` wrapper that verifies another factory's output.
+
+    Runs the plain linear scan alongside the wrapped lookup and raises
+    `RouteLookupError` when a route that would have matched is missing from the
+    candidates, when candidates are out of registration order, duplicated, or
+    foreign to the route table.
+
+    Intended for tests, CI and staging. It is slower than no lookup at all.
+
+        app.route_lookup_factory = StrictRouteLookup(ffroute.RouteLookup)
+    """
+
+    def __init__(self, factory: RouteLookupFactory) -> None:
+        self.factory = factory
+
+    def __call__(self, routes: Sequence[BaseRoute]) -> _StrictRouteLookup:
+        return _StrictRouteLookup(self.factory(routes), routes)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.factory!r})"
+
+
+class _StrictRouteLookup:
+    def __init__(self, lookup: RouteLookup, routes: Sequence[BaseRoute]) -> None:
+        self.lookup = lookup
+        self.routes = routes
+        self.positions = {id(route): index for index, route in enumerate(routes)}
+
+    def candidates(self, scope: Scope, /) -> list[BaseRoute]:
+        candidates = list(self.lookup.candidates(scope))
+        seen: set[int] = set()
+        previous = -1
+        for route in candidates:
+            position = self.positions.get(id(route), -1)
+            if position == -1:
+                raise RouteLookupError(f"{self.lookup!r} returned {route!r}, which is not in the route table.")
+            if id(route) in seen:
+                raise RouteLookupError(f"{self.lookup!r} returned {route!r} more than once.")
+            if position < previous:
+                raise RouteLookupError(f"{self.lookup!r} returned {route!r} out of registration order.")
+            seen.add(id(route))
+            previous = position
+
+        for route in self.routes:
+            if id(route) in seen:
+                continue
+            match, _ = route.matches(scope)
+            if match != Match.NONE:
+                raise RouteLookupError(
+                    f"{self.lookup!r} dropped {route!r}, which matches "
+                    f"{scope['type']} {get_route_path(scope)!r} with {match}."
+                )
+
+        return candidates
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.lookup!r})"
+
+
+def _get_router(app: ASGIApp) -> Router | None:
+    if isinstance(app, Router):
+        return app
+    # `Starlette` and FastAPI applications keep their router on `.router`.
+    router = getattr(app, "router", None)
+    return router if isinstance(router, Router) else None
+
+
+def iter_child_routers(route: BaseRoute) -> Iterator[Router]:
+    """Yield the routers nested inside a route, so a route lookup can be applied
+    to a whole routing tree.
+
+    Handles `Mount` and `Host`, whether they wrap a `Router`, a `Starlette`
+    application, or an application exposing a `.router`. Mounts wrapping opaque
+    ASGI apps, such as `StaticFiles`, yield nothing. Custom route containers can
+    take part by implementing `iter_child_routers()` themselves.
+    """
+    hook = getattr(route, "iter_child_routers", None)
+    if hook is not None:
+        yield from hook()
+        return
+
+    if isinstance(route, Mount):
+        # `_base_app` is the unwrapped app: `route.app` may be a middleware stack,
+        # and middleware does not expose the router underneath it.
+        app: ASGIApp = route._base_app
+    elif isinstance(route, Host):
+        app = route.app
+    else:
+        return
+
+    router = _get_router(app)
+    if router is not None:
+        yield router
+
+
+class _Unset:
+    def __repr__(self) -> str:  # pragma: no cover
+        return "<unset>"
+
+
+# Distinguishes "no route lookup configured, inherit one from a parent router" from
+# `None`, which means "explicitly no route lookup".
+UNSET: Any = _Unset()
+
+
+class _RouteList(list[BaseRoute]):
+    """A list that counts its own mutations.
+
+    `Router.routes` is public and mutated in place all over Starlette, FastAPI and
+    user code. A compiled route lookup has to be rebuilt when that happens, and
+    checking route identity on every request would put an O(N) scan back on the hot
+    path, which is the cost the lookup exists to remove.
+    """
+
+    __slots__ = ("generation",)
+
+    def __init__(self, routes: Iterable[BaseRoute] = ()) -> None:
+        super().__init__(routes)
+        self.generation = 0
+
+    def append(self, route: BaseRoute) -> None:
+        super().append(route)
+        self.generation += 1
+
+    def extend(self, routes: Iterable[BaseRoute]) -> None:
+        super().extend(routes)
+        self.generation += 1
+
+    def insert(self, index: Any, route: BaseRoute) -> None:
+        super().insert(index, route)
+        self.generation += 1
+
+    def remove(self, route: BaseRoute) -> None:
+        super().remove(route)
+        self.generation += 1
+
+    def pop(self, index: SupportsIndex = -1) -> BaseRoute:
+        route = super().pop(index)
+        self.generation += 1
+        return route
+
+    def clear(self) -> None:
+        super().clear()
+        self.generation += 1
+
+    def sort(self, **kwargs: Any) -> None:
+        super().sort(**kwargs)
+        self.generation += 1
+
+    def reverse(self) -> None:
+        super().reverse()
+        self.generation += 1
+
+    def __setitem__(self, index: Any, route: Any) -> None:
+        super().__setitem__(index, route)
+        self.generation += 1
+
+    def __delitem__(self, index: Any) -> None:
+        super().__delitem__(index)
+        self.generation += 1
+
+    def __iadd__(self, routes: Iterable[BaseRoute]) -> _RouteList:  # type: ignore[override,misc]
+        super().__iadd__(routes)
+        self.generation += 1
+        return self
+
+    def __imul__(self, value: SupportsIndex) -> _RouteList:
+        super().__imul__(value)
+        self.generation += 1
+        return self
+
+
+class _RouteTable:
+    """An immutable snapshot of a router's routes and the lookup compiled for them."""
+
+    __slots__ = ("source", "generation", "routes", "lookup")
+
+    def __init__(
+        self,
+        source: _RouteList,
+        routes: tuple[BaseRoute, ...],
+        lookup: RouteLookup | None,
+    ) -> None:
+        self.source = source
+        self.generation = source.generation
+        self.routes = routes
+        self.lookup = lookup
+
+
 class Router:
     def __init__(
         self,
@@ -575,6 +814,9 @@ class Router:
         *,
         middleware: Sequence[Middleware] | None = None,
     ) -> None:
+        self._route_lookup_factory: RouteLookupFactory | None = UNSET
+        self._route_lookup_inherited = False
+        self._route_table: _RouteTable | None = None
         self.routes = [] if routes is None else list(routes)
         self.redirect_slashes = redirect_slashes
         self.default = self.not_found if default is None else default
@@ -602,6 +844,113 @@ class Router:
         if middleware:
             for cls, args, kwargs in reversed(middleware):
                 self.middleware_stack = cls(self.middleware_stack, *args, **kwargs)
+
+    @property
+    def routes(self) -> list[BaseRoute]:
+        return self._routes
+
+    @routes.setter
+    def routes(self, routes: Sequence[BaseRoute]) -> None:
+        self._routes = _RouteList(routes)
+        self.invalidate_route_lookup()
+
+    @property
+    def route_lookup_factory(self) -> RouteLookupFactory | None:
+        """The `RouteLookupFactory` used to narrow route matching.
+
+        Assigning applies to this router *and every nested router below it*, so a
+        single assignment covers mounted sub-applications, routers behind `Host`,
+        and routers mounted later:
+
+            app.route_lookup_factory = ffroute.RouteLookup
+
+        Each router compiles its own lookup from its own routes. A nested router
+        that was configured explicitly keeps its own lookup; assign `None` to turn
+        the lookup off for a subtree and go back to the plain linear scan.
+        """
+        factory = self._route_lookup_factory
+        return None if factory is UNSET else factory
+
+    @route_lookup_factory.setter
+    def route_lookup_factory(self, factory: RouteLookupFactory | None) -> None:
+        self._route_lookup_factory = factory
+        # Explicit beats inherited: a parent will not overwrite this one.
+        self._route_lookup_inherited = False
+        self.invalidate_route_lookup()
+
+    @property
+    def route_lookup(self) -> RouteLookup | None:
+        """The compiled lookup currently in use, or `None` for the linear scan.
+
+        Read-only, and `None` until the lookup is built. Useful to check whether a
+        third-party lookup is actually active.
+        """
+        table = self._route_table
+        return None if table is None else table.lookup
+
+    def invalidate_route_lookup(self) -> None:
+        """Drop the compiled route table so it is rebuilt on next use.
+
+        Adding, removing or replacing routes is detected automatically. Call this
+        after mutating a route object in place, which is invisible from the
+        outside:
+
+            route.path = "/changed"
+            router.invalidate_route_lookup()
+        """
+        self._route_table = None
+
+    def build_route_lookup(self) -> None:
+        """Compile the route lookup for this router and every nested router.
+
+        Called on lifespan startup, so a broken lookup fails at boot instead of on
+        the first request, and no request pays the build cost. Call it directly for
+        apps that never run a lifespan.
+        """
+        visited: set[int] = set()
+        stack: list[Router] = [self]
+        while stack:
+            router = stack.pop()
+            if id(router) in visited:
+                continue
+            visited.add(id(router))
+            table = router._build_route_table()
+            for route in table.routes:
+                stack.extend(iter_child_routers(route))
+
+    def _build_route_table(self) -> _RouteTable:
+        source = self._routes
+        routes = tuple(source)
+        factory = self._route_lookup_factory
+        factory = None if factory is UNSET else factory
+
+        # Push the factory down as part of the build: routers mounted after the
+        # assignment inherit it too, without the route list having to know about
+        # lookups at all.
+        for route in routes:
+            for child in iter_child_routers(route):
+                child._inherit_route_lookup(factory)
+
+        table = _RouteTable(source, routes, None if factory is None else factory(routes))
+        self._route_table = table
+        return table
+
+    def _inherit_route_lookup(self, factory: RouteLookupFactory | None) -> None:
+        if self._route_lookup_factory is not UNSET and not self._route_lookup_inherited:
+            return  # Configured explicitly on this router: leave it alone.
+        if self._route_lookup_inherited and self._route_lookup_factory is factory:
+            return
+        self._route_lookup_factory = factory
+        self._route_lookup_inherited = True
+        self.invalidate_route_lookup()
+
+    def _route_candidates(self, scope: Scope) -> Iterable[BaseRoute]:
+        table = self._route_table
+        routes = self._routes
+        if table is None or table.source is not routes or table.generation != routes.generation:
+            table = self._build_route_table()
+        lookup = table.lookup
+        return table.routes if lookup is None else lookup.candidates(scope)
 
     async def not_found(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] == "websocket":
@@ -633,6 +982,8 @@ class Router:
         """
         started = False
         app: Any = scope.get("app")
+        # Compile now, so a broken route lookup fails startup rather than requests.
+        self.build_route_lookup()
         await receive()
         try:
             async with self.lifespan_context(app) as maybe_state:
@@ -671,7 +1022,7 @@ class Router:
 
         partial = None
 
-        for route in self.routes:
+        for route in self._route_candidates(scope):
             # Determine if any route matches the incoming scope,
             # and hand over to the matching route if found.
             match, child_scope = route.matches(scope)
@@ -699,7 +1050,7 @@ class Router:
             else:
                 redirect_scope["path"] = redirect_scope["path"] + "/"
 
-            for route in self.routes:
+            for route in self._route_candidates(redirect_scope):
                 match, child_scope = route.matches(redirect_scope)
                 if match != Match.NONE:
                     redirect_url = URL(scope=redirect_scope)

--- a/tests/test_route_lookup.py
+++ b/tests/test_route_lookup.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import pytest
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import (
+    BaseRoute,
+    Host,
+    Mount,
+    Route,
+    RouteLookup,
+    RouteLookupError,
+    RouteLookupFactory,
+    Router,
+    StrictRouteLookup,
+    WebSocketRoute,
+    compile_path,
+    get_route_path,
+    iter_child_routers,
+)
+from starlette.staticfiles import StaticFiles
+from starlette.testclient import TestClient
+from starlette.types import Receive, Scope, Send
+from starlette.websockets import WebSocket
+
+
+def named(name: str) -> Any:
+    def handler(request: Request) -> PlainTextResponse:
+        return PlainTextResponse(f"{name} {request.path_params}")
+
+    handler.__name__ = name
+    return handler
+
+
+async def ws_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    await websocket.send_text("ws")
+    await websocket.close()
+
+
+# --- Reference lookups ------------------------------------------------------
+
+
+class AlwaysCandidateLookup:
+    """The most conservative conformant lookup: never narrows anything."""
+
+    def __init__(self, routes: Iterable[BaseRoute]) -> None:
+        self.routes = tuple(routes)
+
+    def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+        return self.routes
+
+
+class FirstSegmentLookup:
+    """Buckets routes by their first literal path segment.
+
+    Deliberately simple, but it really narrows, so it exercises the seam the way a
+    trie would. Anything it does not understand exactly stays always-candidate.
+    """
+
+    def __init__(self, routes: Iterable[BaseRoute]) -> None:
+        routes = tuple(routes)
+        self.positions = {id(route): index for index, route in enumerate(routes)}
+        self.always: list[BaseRoute] = []
+        self.buckets: dict[str, list[BaseRoute]] = {}
+        for route in routes:
+            segment = self._literal_first_segment(route)
+            if segment is None:
+                self.always.append(route)
+            else:
+                self.buckets.setdefault(segment, []).append(route)
+
+    @staticmethod
+    def _literal_first_segment(route: BaseRoute) -> str | None:
+        # Exact type check: a subclass may override `matches()` and match paths its
+        # own `path` does not describe.
+        if type(route) is not Route and type(route) is not WebSocketRoute:
+            return None
+        first = route.path.lstrip("/").split("/")[0]
+        if not first or "{" in first:
+            return None
+        return first
+
+    def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+        first = get_route_path(scope).lstrip("/").split("/")[0]
+        bucket = self.buckets.get(first)
+        if bucket is None:
+            return list(self.always)
+        return sorted(self.always + bucket, key=lambda route: self.positions[id(route)])
+
+
+LOOKUPS: list[RouteLookupFactory | None] = [
+    None,
+    AlwaysCandidateLookup,
+    FirstSegmentLookup,
+    StrictRouteLookup(AlwaysCandidateLookup),
+    StrictRouteLookup(FirstSegmentLookup),
+]
+
+
+@pytest.fixture(params=LOOKUPS, ids=["default", "always", "first-segment", "strict-always", "strict-first-segment"])
+def lookup_factory(request: pytest.FixtureRequest) -> RouteLookupFactory | None:
+    factory: RouteLookupFactory | None = request.param
+    return factory
+
+
+# --- Conformance suite ------------------------------------------------------
+
+CONFORMANCE_ROUTES: list[BaseRoute] = [
+    Route("/", named("root")),
+    Route("/users", named("users"), methods=["GET", "POST"]),
+    Route("/users/me", named("me")),
+    Route("/users/{user_id:int}", named("user")),
+    Route("/users/{user_id}/posts/{post_id}", named("post")),
+    Route("/v{version:int}/ping", named("versioned")),
+    Route("/{username}:disable", named("disable")),
+    Route("/files({file_id:int})", named("parens")),
+    Route("/uploads/{path:path}", named("uploads")),
+    Route("/files-{path:path}", named("compound-path")),
+    Route("/only-post", named("only-post"), methods=["POST"]),
+    Route("/trailing/", named("trailing")),
+    WebSocketRoute("/ws/{room}", ws_endpoint),
+    Mount("/mounted", routes=[Route("/inner", named("inner"))]),
+    Mount("/static", app=StaticFiles(directory="tests"), name="static"),
+    Host("api.example.org", app=Router(routes=[Route("/hosted", named("hosted"))])),
+]
+
+CONFORMANCE_PATHS = [
+    "/",
+    "",
+    "/users",
+    "/users/",
+    "/users/me",
+    "/users/42",
+    "/users/abc",
+    "/users/42/posts/7",
+    "/v1/ping",
+    "/v/ping",
+    "/bob:disable",
+    "/files(7)",
+    "/uploads/a/b/c.txt",
+    "/uploads/",
+    "/files-a/b",
+    "/files-a",
+    "/only-post",
+    "/trailing",
+    "/trailing/",
+    "/ws/lobby",
+    "/mounted/inner",
+    "/mounted",
+    "/static/test_route_lookup.py",
+    "/hosted",
+    "/missing",
+    "/missing/deeper",
+]
+
+
+def assert_route_lookup_conformance(
+    factory: RouteLookupFactory,
+    routes: Iterable[BaseRoute] | None = None,
+    paths: Iterable[str] | None = None,
+) -> None:
+    """Check a `RouteLookupFactory` against `StrictRouteLookup`.
+
+    Third-party lookups can reuse this: build the lookup under `StrictRouteLookup`
+    and probe it, and any dropped, duplicated, reordered or foreign candidate
+    raises `RouteLookupError`.
+    """
+    table = tuple(CONFORMANCE_ROUTES if routes is None else routes)
+    lookup = StrictRouteLookup(factory)(table)
+    for path in CONFORMANCE_PATHS if paths is None else paths:
+        for method in ("GET", "POST", "DELETE"):
+            lookup.candidates(
+                {
+                    "type": "http",
+                    "method": method,
+                    "path": path,
+                    "root_path": "",
+                    "headers": [(b"host", b"api.example.org")],
+                }
+            )
+        lookup.candidates(
+            {
+                "type": "websocket",
+                "path": path,
+                "root_path": "",
+                "headers": [(b"host", b"api.example.org")],
+            }
+        )
+
+
+@pytest.mark.parametrize("factory", [AlwaysCandidateLookup, FirstSegmentLookup])
+def test_reference_lookups_are_conformant(factory: RouteLookupFactory) -> None:
+    assert_route_lookup_conformance(factory)
+
+
+def test_conformance_suite_catches_a_broken_lookup() -> None:
+    class DropsEverything:
+        def __init__(self, routes: Iterable[BaseRoute]) -> None: ...
+
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return []
+
+    with pytest.raises(RouteLookupError, match="dropped"):
+        assert_route_lookup_conformance(DropsEverything)
+
+
+# --- End to end dispatch ----------------------------------------------------
+
+
+def build_app(lookup_factory: RouteLookupFactory | None) -> Starlette:
+    app = Starlette(
+        routes=[
+            Route("/", named("root")),
+            Route("/users", named("users")),
+            Route("/users/me", named("me")),
+            Route("/users/{user_id:int}", named("user")),
+            Route("/only-post", named("only-post"), methods=["POST"]),
+            Route("/trailing/", named("trailing")),
+            WebSocketRoute("/ws/{room}", ws_endpoint),
+            Mount("/mounted", routes=[Route("/inner", named("inner"))]),
+            Host("api.example.org", app=Router(routes=[Route("/hosted", named("hosted"))])),
+        ]
+    )
+    app.route_lookup_factory = lookup_factory
+    return app
+
+
+def test_dispatch_matches_default_behaviour(lookup_factory: RouteLookupFactory | None) -> None:
+    client = TestClient(build_app(lookup_factory))
+
+    assert client.get("/").text == "root {}"
+    assert client.get("/users").text == "users {}"
+    # First registered wins: `/users/me` shadows `/users/{user_id:int}`.
+    assert client.get("/users/me").text == "me {}"
+    assert client.get("/users/42").text == "user {'user_id': 42}"
+    assert client.get("/mounted/inner").text == "inner {}"
+    assert client.get("/missing").status_code == 404
+
+    # Method mismatch must stay a 405, so lookups may not filter on method.
+    response = client.get("/only-post")
+    assert response.status_code == 405
+    assert response.headers["allow"] == "POST"
+
+    # Trailing slash redirects go through the lookup too.
+    response = client.get("/trailing", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"].endswith("/trailing/")
+
+    with client.websocket_connect("/ws/lobby") as websocket:
+        assert websocket.receive_text() == "ws"
+
+    assert client.get("http://api.example.org/hosted").text == "hosted {}"
+
+
+def test_dispatch_under_root_path(lookup_factory: RouteLookupFactory | None) -> None:
+    app = build_app(lookup_factory)
+    client = TestClient(app, root_path="/sub")
+
+    assert client.get("/sub/users/me").text == "me {}"
+    assert client.get("/sub/mounted/inner").text == "inner {}"
+
+
+def test_nested_mounts_dispatch(lookup_factory: RouteLookupFactory | None) -> None:
+    inner = Starlette(routes=[Route("/deep", named("deep"))])
+    middle = Starlette(routes=[Mount("/inner", app=inner)])
+    app = Starlette(routes=[Mount("/middle", app=middle)])
+    app.route_lookup_factory = lookup_factory
+
+    client = TestClient(app)
+    assert client.get("/middle/inner/deep").text == "deep {}"
+
+
+# --- Propagation ------------------------------------------------------------
+
+
+def factories(*routers: Router) -> list[RouteLookupFactory | None]:
+    return [router.route_lookup_factory for router in routers]
+
+
+def test_propagates_into_mounted_routes() -> None:
+    mount = Mount("/api", routes=[Route("/x", named("x"))])
+    app = Starlette(routes=[mount])
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    child = mount._base_app
+    assert isinstance(child, Router)
+    assert factories(app.router, child) == [FirstSegmentLookup, FirstSegmentLookup]
+    assert isinstance(app.router.route_lookup, FirstSegmentLookup)
+    assert isinstance(child.route_lookup, FirstSegmentLookup)
+
+
+def test_propagates_into_mounted_apps_and_routers() -> None:
+    router = Router(routes=[Route("/a", named("a"))])
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    app = Starlette(routes=[Mount("/router", app=router), Mount("/app", app=subapp)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert factories(router, subapp.router) == [FirstSegmentLookup, FirstSegmentLookup]
+
+
+def test_propagates_through_mount_middleware() -> None:
+    # `Mount.app` is the middleware stack; the router lives on `_base_app`.
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    mount = Mount("/app", app=subapp, middleware=[Middleware(TrustedHostMiddleware, allowed_hosts=["*"])])
+    app = Starlette(routes=[mount])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert subapp.router.route_lookup_factory is FirstSegmentLookup
+
+
+def test_propagates_through_host() -> None:
+    router = Router(routes=[Route("/hosted", named("hosted"))])
+    app = Starlette(routes=[Host("api.example.org", app=router)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert router.route_lookup_factory is FirstSegmentLookup
+
+
+def test_propagates_through_nested_mounts() -> None:
+    inner = Starlette(routes=[Route("/deep", named("deep"))])
+    middle = Starlette(routes=[Mount("/inner", app=inner)])
+    app = Starlette(routes=[Mount("/middle", app=middle)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert factories(middle.router, inner.router) == [FirstSegmentLookup, FirstSegmentLookup]
+
+
+def test_propagation_ignores_opaque_asgi_apps() -> None:
+    async def raw_asgi(scope: Scope, receive: Receive, send: Send) -> None: ...  # pragma: no cover
+
+    app = Starlette(
+        routes=[
+            Mount("/static", app=StaticFiles(directory="tests")),
+            Mount("/raw", app=raw_asgi),
+        ]
+    )
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()  # must not raise
+
+    assert list(iter_child_routers(app.routes[0])) == []
+    assert list(iter_child_routers(app.routes[1])) == []
+
+
+def test_propagation_reaches_routers_mounted_later() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    app.routes.append(Mount("/later", app=subapp))
+    app.router.build_route_lookup()
+
+    assert subapp.router.route_lookup_factory is FirstSegmentLookup
+    assert TestClient(app).get("/later/b").text == "b {}"
+
+
+def test_explicit_child_configuration_is_not_overwritten() -> None:
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    subapp.route_lookup_factory = AlwaysCandidateLookup
+    app = Starlette(routes=[Mount("/app", app=subapp)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert subapp.route_lookup_factory is AlwaysCandidateLookup
+
+
+def test_reassignment_updates_inherited_children() -> None:
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    app = Starlette(routes=[Mount("/app", app=subapp)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+    assert factories(subapp.router) == [FirstSegmentLookup]
+
+    app.route_lookup_factory = AlwaysCandidateLookup
+    app.router.build_route_lookup()
+    assert factories(subapp.router) == [AlwaysCandidateLookup]
+
+    app.route_lookup_factory = None
+    app.router.build_route_lookup()
+    assert subapp.route_lookup_factory is None
+    assert subapp.router.route_lookup is None
+
+
+def test_same_app_mounted_twice() -> None:
+    shared = Starlette(routes=[Route("/b", named("b"))])
+    app = Starlette(routes=[Mount("/one", app=shared), Mount("/two", app=shared)])
+
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert shared.route_lookup_factory is FirstSegmentLookup
+    client = TestClient(app)
+    assert client.get("/one/b").text == "b {}"
+    assert client.get("/two/b").text == "b {}"
+
+
+def test_cyclic_routing_tree_does_not_recurse_forever() -> None:
+    router = Router()
+    router.routes.append(Mount("/self", app=router))
+    router.route_lookup_factory = FirstSegmentLookup
+
+    router.build_route_lookup()  # must terminate
+
+    assert router.route_lookup_factory is FirstSegmentLookup
+
+
+def test_custom_route_can_expose_child_routers() -> None:
+    child = Router(routes=[Route("/x", named("x"))])
+
+    class CustomMount(Mount):
+        def iter_child_routers(self) -> Iterator[Router]:
+            yield child
+
+    app = Starlette(routes=[CustomMount("/custom", app=child)])
+    app.route_lookup_factory = FirstSegmentLookup
+    app.router.build_route_lookup()
+
+    assert child.route_lookup_factory is FirstSegmentLookup
+
+
+# --- Invalidation -----------------------------------------------------------
+
+
+def test_added_routes_are_picked_up() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = FirstSegmentLookup
+    client = TestClient(app)
+
+    assert client.get("/a").text == "a {}"
+    assert client.get("/b").status_code == 404
+
+    app.routes.append(Route("/b", named("b")))
+    assert client.get("/b").text == "b {}"
+
+
+def test_replaced_route_is_picked_up() -> None:
+    app = Starlette(routes=[Route("/a", named("a")), Route("/b", named("b"))])
+    app.route_lookup_factory = FirstSegmentLookup
+    client = TestClient(app)
+    assert client.get("/b").text == "b {}"
+
+    # Same length, so a length-based staleness check would miss this.
+    app.routes[1] = Route("/c", named("c"))
+    assert client.get("/b").status_code == 404
+    assert client.get("/c").text == "c {}"
+
+
+def test_reordered_routes_are_picked_up() -> None:
+    app = Starlette(routes=[Route("/users/{user_id}", named("param")), Route("/users/me", named("me"))])
+    app.route_lookup_factory = FirstSegmentLookup
+    client = TestClient(app)
+    assert client.get("/users/me").text == "param {'user_id': 'me'}"
+
+    app.routes.reverse()
+    assert client.get("/users/me").text == "me {}"
+
+
+def test_route_list_reassignment_is_picked_up() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = FirstSegmentLookup
+    client = TestClient(app)
+    assert client.get("/a").text == "a {}"
+
+    app.router.routes = [Route("/b", named("b"))]
+    assert client.get("/a").status_code == 404
+    assert client.get("/b").text == "b {}"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda routes: routes.append(Route("/z", named("z"))), id="append"),
+        pytest.param(lambda routes: routes.extend([Route("/z", named("z"))]), id="extend"),
+        pytest.param(lambda routes: routes.insert(0, Route("/z", named("z"))), id="insert"),
+        pytest.param(lambda routes: routes.pop(), id="pop"),
+        pytest.param(lambda routes: routes.remove(routes[0]), id="remove"),
+        pytest.param(lambda routes: routes.clear(), id="clear"),
+        pytest.param(lambda routes: routes.reverse(), id="reverse"),
+        pytest.param(lambda routes: routes.sort(key=lambda route: route.path), id="sort"),
+        pytest.param(lambda routes: routes.__setitem__(0, Route("/z", named("z"))), id="setitem"),
+        pytest.param(lambda routes: routes.__delitem__(0), id="delitem"),
+        pytest.param(lambda routes: routes.__iadd__([Route("/z", named("z"))]), id="iadd"),
+        pytest.param(lambda routes: routes.__imul__(2), id="imul"),
+        pytest.param(lambda routes: routes.__setitem__(slice(0, 1), [Route("/z", named("z"))]), id="setslice"),
+    ],
+)
+def test_every_mutation_invalidates_the_lookup(mutate: Any) -> None:
+    router = Router(routes=[Route("/a", named("a")), Route("/b", named("b"))])
+    router.route_lookup_factory = AlwaysCandidateLookup
+    router.build_route_lookup()
+
+    mutate(router.routes)
+
+    # `_route_candidates` must notice the route list changed under it. The
+    # always-candidate lookup replays the snapshot it was compiled from, so a
+    # stale table shows up as a mismatch with the live routes.
+    assert list(router._route_candidates(http_scope("/a"))) == list(router.routes)
+
+
+def test_in_place_route_mutation_needs_explicit_invalidation() -> None:
+    route = Route("/a", named("a"))
+    app = Starlette(routes=[route])
+    app.route_lookup_factory = FirstSegmentLookup
+    client = TestClient(app)
+    assert client.get("/a").text == "a {}"
+
+    route.path = "/b"
+    route.path_regex, route.path_format, route.param_convertors = compile_path("/b")
+    # The lookup still has it bucketed under "a", and nothing signalled a change.
+    assert client.get("/b").status_code == 404
+
+    app.router.invalidate_route_lookup()
+    assert client.get("/b").text == "a {}"
+
+
+# --- StrictRouteLookup ------------------------------------------------------
+
+
+def strict_lookup(lookup: RouteLookup, routes: list[BaseRoute]) -> RouteLookup:
+    return StrictRouteLookup(lambda _: lookup)(tuple(routes))
+
+
+def http_scope(path: str = "/a") -> Scope:
+    return {"type": "http", "method": "GET", "path": path, "root_path": "", "headers": []}
+
+
+def test_strict_lookup_accepts_a_conformant_lookup() -> None:
+    routes: list[BaseRoute] = [Route("/a", named("a")), Route("/b", named("b"))]
+    lookup = StrictRouteLookup(FirstSegmentLookup)(tuple(routes))
+
+    assert list(lookup.candidates(http_scope("/a"))) == [routes[0]]
+
+
+def test_strict_lookup_rejects_dropped_routes() -> None:
+    routes: list[BaseRoute] = [Route("/a", named("a"))]
+
+    class Drops:
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return []
+
+    with pytest.raises(RouteLookupError, match="dropped"):
+        strict_lookup(Drops(), routes).candidates(http_scope("/a"))
+
+
+def test_strict_lookup_rejects_method_filtering() -> None:
+    # Filtering on method turns a 405 into a 404, so PARTIAL matches count too.
+    routes: list[BaseRoute] = [Route("/a", named("a"), methods=["POST"])]
+
+    class FiltersMethods:
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return []
+
+    with pytest.raises(RouteLookupError, match="Match.PARTIAL"):
+        strict_lookup(FiltersMethods(), routes).candidates(http_scope("/a"))
+
+
+def test_strict_lookup_rejects_out_of_order_candidates() -> None:
+    routes: list[BaseRoute] = [Route("/a", named("a")), Route("/a", named("a2"))]
+
+    class Reorders:
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return list(reversed(routes))
+
+    with pytest.raises(RouteLookupError, match="out of registration order"):
+        strict_lookup(Reorders(), routes).candidates(http_scope("/a"))
+
+
+def test_strict_lookup_rejects_duplicates() -> None:
+    routes: list[BaseRoute] = [Route("/a", named("a"))]
+
+    class Duplicates:
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return [routes[0], routes[0]]
+
+    with pytest.raises(RouteLookupError, match="more than once"):
+        strict_lookup(Duplicates(), routes).candidates(http_scope("/a"))
+
+
+def test_strict_lookup_rejects_foreign_routes() -> None:
+    routes: list[BaseRoute] = [Route("/a", named("a"))]
+    foreign = Route("/foreign", named("foreign"))
+
+    class Foreign:
+        def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]:
+            return [foreign]
+
+    with pytest.raises(RouteLookupError, match="not in the route table"):
+        strict_lookup(Foreign(), routes).candidates(http_scope("/a"))
+
+
+def test_strict_lookup_repr() -> None:
+    assert "AlwaysCandidateLookup" in repr(StrictRouteLookup(AlwaysCandidateLookup))
+    lookup = StrictRouteLookup(AlwaysCandidateLookup)(())
+    assert "AlwaysCandidateLookup" in repr(lookup)
+
+
+# --- Lifecycle --------------------------------------------------------------
+
+
+def test_lookup_is_built_on_startup() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = FirstSegmentLookup
+
+    assert app.router.route_lookup is None
+    with TestClient(app):
+        assert isinstance(app.router.route_lookup, FirstSegmentLookup)
+
+
+def test_broken_lookup_fails_at_startup() -> None:
+    def broken(routes: Iterable[BaseRoute]) -> RouteLookup:
+        raise ValueError("unsupported route table")
+
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = broken
+
+    with pytest.raises(ValueError, match="unsupported route table"):
+        with TestClient(app):
+            pass  # pragma: no cover
+
+
+def test_startup_builds_nested_routers() -> None:
+    subapp = Starlette(routes=[Route("/b", named("b"))])
+    app = Starlette(routes=[Mount("/app", app=subapp)])
+    app.route_lookup_factory = FirstSegmentLookup
+
+    with TestClient(app):
+        assert isinstance(subapp.router.route_lookup, FirstSegmentLookup)
+
+
+def test_defaults_are_unchanged() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+
+    assert app.route_lookup_factory is None
+    assert app.router.route_lookup is None
+    assert TestClient(app).get("/a").text == "a {}"
+    assert app.router.route_lookup is None
+
+
+def test_router_lookup_can_be_configured_directly() -> None:
+    router = Router(routes=[Route("/a", named("a"))])
+    router.route_lookup_factory = FirstSegmentLookup
+
+    assert TestClient(router).get("/a").text == "a {}"
+    assert isinstance(router.route_lookup, FirstSegmentLookup)


### PR DESCRIPTION
## Summary

Adds a narrow extension point for replacing the linear route scan, so third-party
routers (Rust tries, radix trees, generated matchers) can plug in without
subclassing `Router`, swapping `__class__`, or copying `Router.app()`.

Nothing changes by default. There is no new dependency, no behaviour change, and
no performance change for apps that do not opt in.

## Motivation

[`jirikuncar/ffroute`](https://github.com/jirikuncar/ffroute) is a Rust/PyO3 trie
matcher that is 100-200x faster than Starlette's linear regex scan on real OpenAPI
specs. To integrate today it has to:

* mutate `router.__class__` into a dynamically synthesised mixin
* rebind `middleware_stack`, because `Router.__init__` caches `self.app` as a bound
  method and the class swap would otherwise be dormant
* reimplement most of `Router.app()`, then fall back to `super().app()` on a miss,
  which runs the linear scan a second time
* walk the routing tree itself to reach mounted sub-apps, missing any `Mount` that
  has `middleware=[...]`, since `Mount.app` is the middleware stack rather than the
  router

All of that is a symptom of Starlette not offering a seam. This PR adds one.

## API

```python
class RouteLookup(Protocol):
    def candidates(self, scope: Scope, /) -> Iterable[BaseRoute]: ...

RouteLookupFactory = Callable[[Sequence[BaseRoute]], RouteLookup]
```

```python
app.route_lookup_factory = ffroute.RouteLookup
```

A lookup never decides a match. It only narrows the routes a router checks, and
`Route.matches()` still runs on every candidate, so path params, convertors,
`Mount`, `Host`, WebSockets, trailing-slash redirects, 405s and
first-registered-wins ordering are untouched.

Assignment applies to the whole routing tree: mounted apps, routers behind `Host`,
nested mounts, and routers mounted *later* all inherit it, each compiling its own
lookup from its own routes. A nested router configured explicitly keeps its own.
Assigning `None` restores the linear scan for that subtree.

Also public: `StrictRouteLookup`, `RouteLookupError`, `iter_child_routers()`,
`Router.invalidate_route_lookup()`, `Router.build_route_lookup()`,
`Router.route_lookup` (read-only), and `get_route_path()` re-exported from
`starlette.routing` so implementations stop importing `starlette._utils`.

## Design notes

**Propagation happens at build time, not on assignment.** Compiling a router's
route table pushes the factory one level down. Routers mounted after the
assignment inherit automatically, cycles terminate because each router propagates
only one level, and assignment stays a local mutation.

**`Router.routes` is now a private `list` subclass that counts mutations.** It is
public and mutated in place all over Starlette, FastAPI and user code, so a
compiled lookup has to know when it goes stale. Checking route identity per
request would put the O(N) scan back on the hot path. `append`, `extend`,
`insert`, `remove`, `pop`, `clear`, `sort`, `reverse`, `__setitem__`,
`__delitem__`, `__iadd__`, `__imul__` and reassignment are all covered; each has a
test. A length-only check is not enough: `routes[1] = other` and `routes.reverse()`
have to invalidate too.

**Child discovery uses `Mount._base_app`, not `Mount.app`**, so mounts with
middleware are reached.

**Lookups compile on lifespan startup**, so a broken lookup fails at boot rather
than as a per-request 500, and no request pays the build cost.

## Safety

A dropped candidate is a silent 404, and security-relevant when the dropped route
was the authenticated one. So the contract is explicit in `RouteLookup`'s docstring
and in the docs, and Starlette ships the oracle rather than making every
implementer reinvent it:

```python
app.route_lookup_factory = StrictRouteLookup(ffroute.RouteLookup)
```

It runs the linear scan alongside the lookup and raises `RouteLookupError` on a
dropped, duplicated, reordered or foreign candidate. The dropped check uses
`Match.FULL` **or** `Match.PARTIAL`, so a lookup that filters on method is
rejected instead of silently turning 405s into 404s.

`tests/test_route_lookup.py` includes `assert_route_lookup_conformance()`, a
reusable suite of 16 tricky routes crossed with 26 paths and four scope shapes,
and the dispatch tests run under five configurations: default, always-candidate,
a real narrowing lookup, and both wrapped in strict mode.

## Performance

No measurable change for the default path (`linear` is unchanged, the added cost
is one attribute load and a branch):

| routes | scenario | main | this PR |
|---|---|---|---|
| 5 | miss | 3.33 us | 3.45 us |
| 20 | miss | 8.31 us | 8.72 us |
| 100 | miss | 36.40 us | 35.18 us |

With the naive bucket lookup from the test file installed, to show the seam is
where the win comes from rather than the implementation behind it:

| routes | scenario | linear | lookup |
|---|---|---|---|
| 500 | hit | 162.1 us | 68.8 us |
| 500 | miss | 170.7 us | 2.0 us |

A pure-Python trie lookup is proposed separately in #TRIE_PR, so this PR can be
judged purely as an API change.

## Open questions

1. Explicit-child-wins vs last-assignment-wins when a parent and a mounted app
   both configure a lookup. This PR implements explicit-child-wins.
2. `iter_child_routers()` as a module function with a duck-typed hook, as here, or
   a method on `BaseRoute`?
3. Should Starlette commit publicly to "a `Mount` only matches paths under its
   `path` prefix", so lookups may index mounts instead of treating them as
   always-candidates?
4. Should the conformance helper ship in a public `starlette.testing` module?
5. Constructor keyword (`Starlette(route_lookup_factory=...)`) in addition to the
   property?

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed
and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

