### PR TITLE
Add TrieRouteLookup, a pure-Python segment trie route lookup

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -345,19 +345,39 @@ candidate, so path parameters, convertors, `Mount`, `Host`, WebSockets, trailing
 slash redirects, `405 Method Not Allowed` and first-registered-wins ordering all
 behave exactly as before.
 
-Install one by assigning a factory:
+Starlette ships one, `TrieRouteLookup`, and you can write your own. Install it by
+assigning a factory:
 
 ```python
 from starlette.applications import Starlette
+from starlette.routing import TrieRouteLookup
 
 app = Starlette(routes=routes)
-app.route_lookup_factory = SomeRouteLookup
+app.route_lookup_factory = TrieRouteLookup
 ```
 
 The assignment applies to the whole routing tree: mounted applications, routers
 behind `Host`, nested mounts, and routers mounted later all inherit it, and each
 one compiles its own lookup from its own routes. A nested router that was given a
 lookup of its own keeps it. Assign `None` to go back to the plain linear scan.
+
+### The built-in trie
+
+`TrieRouteLookup` indexes route paths in a segment trie, so a request walks the
+path one segment at a time instead of running every route's regex. It is worth
+turning on when you have a few hundred routes, or a lot of traffic that matches
+nothing, such as bots and scanners: a trie stops at the first segment that leads
+nowhere, while the linear scan has to run every regex before concluding there is
+no match.
+
+`Route` and `WebSocketRoute` are indexed by path. `Mount`, `Host`, route
+subclasses, and any segment the trie cannot represent exactly, such as one whose
+convertor could match a `/`, are checked on every request, so behaviour never
+changes, only the number of routes that get checked.
+
+Custom convertors are indexed too, as long as their regex can be shown not to
+match a `/`. When that cannot be proven, the route stays a candidate for every
+request.
 
 ### Writing a route lookup
 

--- a/scripts/bench_route_lookup.py
+++ b/scripts/bench_route_lookup.py
@@ -1,0 +1,209 @@
+"""Benchmark route lookups against the default linear scan.
+
+    uv run python scripts/bench_route_lookup.py
+
+Reports three things for a few route table sizes:
+
+* end to end `Router` dispatch, hits and misses
+* candidate selection on its own, which is the part a lookup replaces
+* one time build cost of the lookup
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable, Sequence
+
+from starlette.responses import PlainTextResponse
+from starlette.routing import BaseRoute, Match, Route, Router, RouteLookupFactory, TrieRouteLookup
+
+LOOKUPS: list[tuple[str, RouteLookupFactory | None]] = [
+    ("linear", None),
+    ("trie", TrieRouteLookup),
+]
+
+
+async def endpoint(request: object) -> PlainTextResponse:
+    return PlainTextResponse("ok")
+
+
+def make_routes(count: int) -> list[BaseRoute]:
+    """A REST shaped route table: static collections, typed and string params."""
+    routes: list[BaseRoute] = []
+    index = 0
+    while len(routes) < count:
+        name = f"resource{index}"
+        routes.extend(
+            [
+                Route(f"/api/v1/{name}", endpoint),
+                Route(f"/api/v1/{name}/{{{name}_id:int}}", endpoint),
+                Route(f"/api/v1/{name}/{{{name}_id:int}}/items", endpoint),
+                Route(f"/api/v1/{name}/{{{name}_id:int}}/items/{{item_id}}", endpoint),
+                Route(f"/api/v1/{name}/{{{name}_id:int}}/items/{{item_id}}/history", endpoint),
+            ]
+        )
+        index += 1
+    return routes[:count]
+
+
+def make_probes(routes: Sequence[BaseRoute]) -> tuple[list[str], list[str]]:
+    hits: list[str] = []
+    for route in routes:
+        path = route.path  # type: ignore[attr-defined]
+        path = path.replace("_id:int}", "_id}")
+        parts = []
+        for segment in path.lstrip("/").split("/"):
+            parts.append("7" if segment.endswith("_id}") else segment)
+        hits.append("/" + "/".join(parts))
+
+    misses = [path.replace("/api/", "/apiv/", 1) for path in hits]
+    for path in misses:
+        scope = {"type": "http", "method": "GET", "path": path, "root_path": "", "headers": []}
+        assert all(route.matches(scope)[0] == Match.NONE for route in routes), path
+    return hits, misses
+
+
+def scope_for(path: str) -> dict[str, object]:
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "root_path": "",
+        "headers": [],
+        "query_string": b"",
+        "scheme": "http",
+        "http_version": "1.1",
+        "client": ("test", 1),
+        "server": ("test", 80),
+    }
+
+
+def best_of(runs: int, work: Callable[[], None], iterations: int) -> float:
+    best = None
+    for _ in range(runs):
+        start = time.perf_counter()
+        work()
+        elapsed = (time.perf_counter() - start) / iterations
+        best = elapsed if best is None else min(best, elapsed)
+    assert best is not None
+    return best
+
+
+async def bench_dispatch(router: Router, paths: Sequence[str]) -> float:
+    scopes = [scope_for(path) for path in paths]
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, object]) -> None:
+        return None
+
+    async def work() -> None:
+        for scope in scopes:
+            await router(dict(scope), receive, send)
+
+    await work()  # warm up and build the lookup
+
+    best = None
+    for _ in range(5):
+        start = time.perf_counter()
+        await work()
+        elapsed = (time.perf_counter() - start) / len(scopes)
+        best = elapsed if best is None else min(best, elapsed)
+    assert best is not None
+    return best * 1e6
+
+
+def bench_resolve(routes: Sequence[BaseRoute], factory: RouteLookupFactory | None, paths: Sequence[str]) -> float:
+    """Time the routing decision itself: find the route, without dispatching it."""
+    scopes = [scope_for(path) for path in paths]
+    candidates: Callable[[dict[str, object]], Sequence[BaseRoute]]
+    if factory is None:
+        snapshot = tuple(routes)
+        candidates = lambda scope: snapshot  # noqa: E731
+    else:
+        lookup = factory(tuple(routes))
+        candidates = lambda scope: list(lookup.candidates(scope))  # noqa: E731
+
+    def work() -> None:
+        for scope in scopes:
+            partial = None
+            for route in candidates(scope):
+                match, _ = route.matches(scope)
+                if match == Match.FULL:
+                    break
+                if match == Match.PARTIAL and partial is None:
+                    partial = route
+
+    work()
+    return best_of(5, work, len(scopes)) * 1e9
+
+
+def bench_build(routes: Sequence[BaseRoute], factory: RouteLookupFactory | None) -> float:
+    if factory is None:
+        return 0.0
+    snapshot = tuple(routes)
+
+    def work() -> None:
+        factory(snapshot)
+
+    work()
+    return best_of(5, work, 1) * 1e3
+
+
+async def main() -> None:
+    sizes = [5, 20, 50, 200, 740, 2000]
+
+    rows: list[tuple[str, ...]] = []
+    for size in sizes:
+        routes = make_routes(size)
+        hits, misses = make_probes(routes)
+        results: dict[str, tuple[float, float, float, float, float]] = {}
+        for name, factory in LOOKUPS:
+            router = Router(routes=list(routes))
+            router.route_lookup_factory = factory
+            hit_us = await bench_dispatch(router, hits)
+            miss_us = await bench_dispatch(router, misses)
+            hit_ns = bench_resolve(routes, factory, hits)
+            miss_ns = bench_resolve(routes, factory, misses)
+            build_ms = bench_build(routes, factory)
+            results[name] = (hit_us, miss_us, hit_ns, miss_ns, build_ms)
+
+        linear = results["linear"]
+        trie = results["trie"]
+        rows.append(
+            (
+                str(size),
+                f"{linear[0]:.1f} / {trie[0]:.1f}",
+                f"{linear[0] / trie[0]:.1f}x",
+                f"{linear[1]:.1f} / {trie[1]:.1f}",
+                f"{linear[1] / trie[1]:.1f}x",
+                f"{linear[2]:.0f} / {trie[2]:.0f}",
+                f"{linear[2] / trie[2]:.1f}x",
+                f"{linear[3]:.0f} / {trie[3]:.0f}",
+                f"{linear[3] / trie[3]:.1f}x",
+                f"{trie[4]:.2f}",
+            )
+        )
+
+    header = (
+        "routes",
+        "dispatch hit us",
+        "x",
+        "dispatch miss us",
+        "x",
+        "resolve hit ns",
+        "x",
+        "resolve miss ns",
+        "x",
+        "build ms",
+    )
+    print("| " + " | ".join(header) + " |")
+    print("|" + "|".join("---" for _ in header) + "|")
+    for row in rows:
+        print("| " + " | ".join(row) + " |")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/starlette/_trie.py
+++ b/starlette/_trie.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import re
+from re import Pattern
+
+from starlette.convertors import (
+    Convertor,
+    FloatConvertor,
+    IntegerConvertor,
+    PathConvertor,
+    StringConvertor,
+    UUIDConvertor,
+)
+
+# Match parameters in URL paths, eg. '{param}', and '{param:int}'.
+PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)(:[a-zA-Z_][a-zA-Z0-9_]*)?}")
+
+# Built-in convertors whose regex is known to stay inside a single path segment.
+_SEGMENT_LOCAL_CONVERTORS = (StringConvertor, IntegerConvertor, FloatConvertor, UUIDConvertor)
+
+# Escapes that cannot match a '/'. Anything else, including `\S`, `\D`, `\W` and
+# numeric escapes such as `\x2f`, is treated as unknown.
+_SAFE_ESCAPES = frozenset("dwsbBAZznrtfv")
+
+
+def _escape_may_match_slash(escape: str) -> bool:
+    if escape in _SAFE_ESCAPES:
+        return False
+    # `\/` is a literal slash, `\x2f` and `\1` are opaque, and an escaped
+    # punctuation character is itself.
+    return escape.isalnum() or escape == "/"
+
+
+def _class_may_match_slash(body: str) -> bool:
+    """Whether a character class body, the `...` of `[...]`, can match a '/'."""
+    negated = body.startswith("^")
+    if negated:
+        body = body[1:]
+
+    lists_slash = False
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char == "\\":
+            escape = body[index + 1 : index + 2]
+            if escape == "/":
+                lists_slash = True
+            elif _escape_may_match_slash(escape):
+                return True  # Unknown escape: do not try to reason about it.
+            index += 2
+            continue
+        if body[index + 1 : index + 2] == "-" and index + 2 < len(body):
+            if body[index + 2] == "\\":
+                return True  # Escaped range bound: unknown.
+            lists_slash = lists_slash or char <= "/" <= body[index + 2]
+            index += 3
+            continue
+        lists_slash = lists_slash or char == "/"
+        index += 1
+
+    return not lists_slash if negated else lists_slash
+
+
+def _pattern_may_match_slash(pattern: str) -> bool:
+    """Conservatively decide whether a regex can match a '/'.
+
+    A segment trie can only index a route when each of its segments stays inside a
+    single path segment. Anything this cannot prove to be slash-free is reported as
+    slash-capable, which costs a fast path but never a match.
+    """
+    index = 0
+    length = len(pattern)
+    while index < length:
+        char = pattern[index]
+        if char == "\\":
+            if _escape_may_match_slash(pattern[index + 1 : index + 2]):
+                return True
+            index += 2
+            continue
+        if char == "[":
+            end = index + 1
+            if pattern[end : end + 1] == "^":
+                end += 1
+            if pattern[end : end + 1] == "]":  # A leading ']' is a literal.
+                end += 1
+            while end < length and pattern[end] != "]":
+                end += 2 if pattern[end] == "\\" else 1
+            if end == length:
+                return True  # Unbalanced class: not something to parse.
+            if _class_may_match_slash(pattern[index + 1 : end]):
+                return True
+            index = end + 1
+            continue
+        if char in "./":
+            # `.` matches '/' unless the pattern is compiled without DOTALL, which
+            # is not something a convertor regex can be assumed to control.
+            return True
+        index += 1
+
+    return False
+
+
+def _may_match_slash(convertor: Convertor[object]) -> bool:
+    if type(convertor) in _SEGMENT_LOCAL_CONVERTORS:
+        return False
+    return _pattern_may_match_slash(convertor.regex)
+
+
+def _segment_regex(segment: str, convertors: dict[str, Convertor[object]]) -> Pattern[str]:
+    parts = ["^"]
+    index = 0
+    for match in PARAM_REGEX.finditer(segment):
+        parts.append(re.escape(segment[index : match.start()]))
+        # Group the convertor regex so alternation keeps segment-local precedence,
+        # the way the named group in `compile_path` does.
+        parts.append(f"(?:{convertors[match.group(1)].regex})")
+        index = match.end()
+    parts.append(re.escape(segment[index:]))
+    parts.append("$")
+    return re.compile("".join(parts))
+
+
+class Node:
+    __slots__ = ("static", "param", "dynamic", "path_indices", "indices")
+
+    def __init__(self) -> None:
+        self.static: dict[str, Node] = {}
+        self.param: Node | None = None
+        self.dynamic: list[tuple[Pattern[str], Node]] = []
+        # Routes ending in a `path` convertor: they match any remainder from here.
+        self.path_indices: list[int] = []
+        self.indices: list[int] = []
+
+
+class RouteTrie:
+    """A candidate-narrowing segment trie over route paths.
+
+    `match_all()` returns a superset of the routes whose `path_regex` could match a
+    path, in registration order. It never decides a match on its own: the caller
+    still runs `BaseRoute.matches()` on every candidate.
+
+    Segment patterns come from each route's own `param_convertors` rather than
+    being re-parsed from the path, so custom convertors and the exact built-in
+    regexes are honoured. Anything that cannot be indexed exactly, such as a
+    segment that could span a '/', is registered as an always-candidate.
+    """
+
+    __slots__ = ("root", "always")
+
+    def __init__(self) -> None:
+        self.root = Node()
+        self.always: list[int] = []
+
+    def add_always(self, index: int) -> None:
+        """Register a route that has to be checked for every path."""
+        self.always.append(index)
+
+    def add(self, index: int, path: str, convertors: dict[str, Convertor[object]]) -> None:
+        """Index a route path, falling back to an always-candidate when needed."""
+        node = self.root
+        for segment in path[1:].split("/"):
+            if "{" not in segment:
+                child = node.static.get(segment)
+                if child is None:
+                    child = node.static[segment] = Node()
+                node = child
+                continue
+
+            match = PARAM_REGEX.fullmatch(segment)
+            if match is not None:
+                convertor = convertors[match.group(1)]
+                if type(convertor) is StringConvertor:
+                    if node.param is None:
+                        node.param = Node()
+                    node = node.param
+                    continue
+                if type(convertor) is PathConvertor:
+                    # Consumes the rest of the path, so the route ends here.
+                    node.path_indices.append(index)
+                    return
+
+            if any(_may_match_slash(convertors[param.group(1)]) for param in PARAM_REGEX.finditer(segment)):
+                # The segment can span a '/', which a per-segment trie cannot model.
+                self.add_always(index)
+                return
+
+            regex = _segment_regex(segment, convertors)
+            child = next((child for pattern, child in node.dynamic if pattern.pattern == regex.pattern), None)
+            if child is None:
+                child = Node()
+                node.dynamic.append((regex, child))
+            node = child
+
+        node.indices.append(index)
+
+    def match_all(self, path: str) -> list[int]:
+        """Return the indices of every route that could match `path`, in order."""
+        indices = list(self.always)
+        self._walk(self.root, path[1:] if path.startswith("/") else path, indices)
+        indices.sort()
+        return indices
+
+    def _walk(self, node: Node, rest: str, indices: list[int]) -> None:
+        segment, slash, tail = rest.partition("/")
+
+        if slash:
+            child = node.static.get(segment)
+            if child is not None:
+                self._walk(child, tail, indices)
+            if segment and node.param is not None:
+                self._walk(node.param, tail, indices)
+            for pattern, child in node.dynamic:
+                if pattern.match(segment):
+                    self._walk(child, tail, indices)
+        else:
+            child = node.static.get(segment)
+            if child is not None:
+                indices.extend(child.indices)
+            if segment and node.param is not None:
+                indices.extend(node.param.indices)
+            for pattern, child in node.dynamic:
+                if pattern.match(segment):
+                    indices.extend(child.indices)
+
+        # A `path` convertor registered here matches whatever is left, including
+        # the empty string.
+        indices.extend(node.path_indices)

--- a/starlette/routing.py
+++ b/starlette/routing.py
@@ -14,6 +14,7 @@ from re import Pattern
 from typing import Any, Protocol, SupportsIndex, TypeVar
 
 from starlette._exception_handler import wrap_app_handling_exceptions
+from starlette._trie import RouteTrie
 
 # `get_route_path` is part of the public API: route lookup implementations need it to
 # resolve the path a router matches against, with `root_path` stripped.
@@ -670,6 +671,38 @@ class _StrictRouteLookup:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.lookup!r})"
+
+
+class TrieRouteLookup:
+    """A `RouteLookupFactory` backed by a segment trie.
+
+    Narrows the routes a router checks by walking the path one segment at a time,
+    instead of running every route's `path_regex`. It returns a superset of the
+    routes that could match, in registration order, so `Route.matches()` still
+    decides and every routing behaviour is preserved.
+
+        app.route_lookup_factory = TrieRouteLookup
+
+    `Route` and `WebSocketRoute` are indexed by path. `Mount`, `Host`, route
+    subclasses and anything else are always-candidates, and so are paths the trie
+    cannot represent exactly, such as a segment whose convertor could match a '/'.
+    """
+
+    def __init__(self, routes: Sequence[BaseRoute]) -> None:
+        self.routes = tuple(routes)
+        trie = RouteTrie()
+        for index, route in enumerate(self.routes):
+            # Exact type check: a subclass may override `matches()` and match paths
+            # its own `path` does not describe.
+            if type(route) is Route or type(route) is WebSocketRoute:
+                trie.add(index, route.path, route.param_convertors)
+            else:
+                trie.add_always(index)
+        self.trie = trie
+
+    def candidates(self, scope: Scope, /) -> list[BaseRoute]:
+        routes = self.routes
+        return [routes[index] for index in self.trie.match_all(get_route_path(scope))]
 
 
 def _get_router(app: ASGIApp) -> Router | None:

--- a/tests/test_convertors.py
+++ b/tests/test_convertors.py
@@ -16,7 +16,10 @@ from tests.types import TestClientFactory
 def refresh_convertor_types() -> Iterator[None]:
     convert_types = convertors.CONVERTOR_TYPES.copy()
     yield
-    convertors.CONVERTOR_TYPES = convert_types
+    # Restore in place: `starlette.routing` imports `CONVERTOR_TYPES` by value, so
+    # rebinding the module attribute would leave routing pointing at a stale dict.
+    convertors.CONVERTOR_TYPES.clear()
+    convertors.CONVERTOR_TYPES.update(convert_types)
 
 
 class DateTimeConvertor(Convertor[datetime]):

--- a/tests/test_trie_lookup.py
+++ b/tests/test_trie_lookup.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from starlette import convertors
+from starlette._trie import RouteTrie, _pattern_may_match_slash
+from starlette.applications import Starlette
+from starlette.convertors import Convertor, StringConvertor, register_url_convertor
+from starlette.responses import PlainTextResponse
+from starlette.routing import BaseRoute, Host, Mount, Route, Router, TrieRouteLookup, WebSocketRoute
+from starlette.testclient import TestClient
+from tests.test_route_lookup import (
+    CONFORMANCE_PATHS,
+    CONFORMANCE_ROUTES,
+    assert_route_lookup_conformance,
+    named,
+    ws_endpoint,
+)
+
+
+def build(paths: list[str]) -> tuple[RouteTrie, list[Route]]:
+    trie = RouteTrie()
+    routes = []
+    for index, path in enumerate(paths):
+        route = Route(path, endpoint=named(f"r{index}"))
+        routes.append(route)
+        trie.add(index, route.path, route.param_convertors)
+    return trie, routes
+
+
+def assert_superset(paths: list[str], probes: list[str]) -> None:
+    """The trie must never drop a route whose real `path_regex` matches."""
+    trie, routes = build(paths)
+    for probe in probes:
+        oracle = {index for index, route in enumerate(routes) if route.path_regex.match(probe)}
+        candidates = set(trie.match_all(probe))
+        dropped = oracle - candidates
+        assert not dropped, f"{probe!r} dropped {[paths[index] for index in dropped]}"
+
+
+# --- Slash detection --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        ("[^/]+", False),
+        ("[0-9]+", False),
+        (r"[0-9]+(\.[0-9]+)?", False),
+        ("[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}", False),
+        ("[a-z0-9-]+", False),
+        ("a|b", False),
+        (r"\d+", False),
+        (r"\w+", False),
+        (r"\-", False),
+        ("[]a]", False),
+        (r"[\]]", False),
+        (r"[\d]", False),
+        ("[a-c]", False),
+        (".*", True),
+        ("a.b", True),
+        ("/", True),
+        (r"\/", True),
+        (r"\S+", True),
+        (r"\D+", True),
+        (r"\W+", True),
+        (r"\x2f", True),
+        (r"\1", True),
+        ("[^a]", True),
+        ("[/]", True),
+        (r"[\/]", True),
+        ("[!-9]", True),
+        (r"[\S]", True),
+        (r"[a-\x7f]", True),
+        ("[abc", True),
+        ("[^/", True),
+    ],
+)
+def test_pattern_slash_detection(pattern: str, expected: bool) -> None:
+    assert _pattern_may_match_slash(pattern) is expected
+
+
+# --- Superset property ------------------------------------------------------
+
+
+def test_static_and_param() -> None:
+    assert_superset(
+        ["/users", "/users/{id}", "/users/me", "/"],
+        ["/users", "/users/42", "/users/me", "/users/", "/missing", "/", ""],
+    )
+
+
+def test_typed_convertors() -> None:
+    assert_superset(
+        ["/int/{x:int}", "/float/{x:float}", "/uuid/{x:uuid}", "/{x}"],
+        [
+            "/int/5",
+            "/int/abc",
+            "/float/2.5",
+            "/uuid/ec38df32-ceda-4cfa-9b4a-1aeb94ad551a",
+            "/uuid/EC38DF32CEDA4CFA9B4A1AEB94AD551A",
+            "/x",
+        ],
+    )
+
+
+def test_path_convertor_consumes_remainder() -> None:
+    assert_superset(
+        ["/static/{file:path}", "/static/list", "/{everything:path}"],
+        ["/static/a/b/c.txt", "/static/", "/static/list", "/static", "/", "/anything/at/all"],
+    )
+
+
+def test_compound_segments() -> None:
+    assert_superset(
+        ["/v{n:int}", "/{name}:disable", "/files({id:int})", "/x{a:int}y{b:int}z"],
+        ["/v5", "/bob:disable", "/files(7)", "/x1y2z", "/v", "/bob"],
+    )
+
+
+def test_slash_capable_convertor_in_compound_segment() -> None:
+    # A `path` convertor inside a compound segment can span segments, which the
+    # trie cannot index, so the route has to stay an always-candidate.
+    assert_superset(
+        ["/files-{p:path}", "/static/{p:path}"],
+        ["/files-a/b", "/files-a", "/files-", "/static/a/b/c", "/static/"],
+    )
+
+
+def test_shared_nodes() -> None:
+    assert_superset(
+        ["/a/{x}/b", "/a/{y}/c", "/v{n:int}/x", "/v{m:int}/y"],
+        ["/a/1/b", "/a/1/c", "/v5/x", "/v5/y"],
+    )
+
+
+def test_custom_convertor_is_indexed_when_slash_free() -> None:
+    class HexConvertor(Convertor[int]):
+        regex = "[0-9a-f]+"
+
+        def convert(self, value: str) -> int:
+            return int(value, 16)  # pragma: no cover
+
+        def to_string(self, value: int) -> str:
+            return format(value, "x")  # pragma: no cover
+
+    register_url_convertor("hex_trie_test", HexConvertor())
+    try:
+        trie, _ = build(["/h/{x:hex_trie_test}", "/h/{y}"])
+        assert trie.always == []  # Indexed, not a fallback.
+        assert_superset(["/h/{x:hex_trie_test}", "/h/{y}"], ["/h/deadbeef", "/h/xyz"])
+    finally:
+        convertors.CONVERTOR_TYPES.pop("hex_trie_test", None)
+
+
+def test_custom_convertor_with_alternation() -> None:
+    # Without grouping, `^x(a|b)y$` would compile as `^xa|by$` and drop `/xby`.
+    class AltConvertor(StringConvertor):
+        regex = "a|b"
+
+    register_url_convertor("alt_trie_test", AltConvertor())
+    try:
+        assert_superset(["/x{p:alt_trie_test}y"], ["/xay", "/xby", "/xcy"])
+    finally:
+        convertors.CONVERTOR_TYPES.pop("alt_trie_test", None)
+
+
+def test_slash_capable_custom_convertor_falls_back() -> None:
+    class AnythingConvertor(Convertor[str]):
+        regex = ".+"
+
+        def convert(self, value: str) -> str:
+            return value  # pragma: no cover
+
+        def to_string(self, value: str) -> str:
+            return value  # pragma: no cover
+
+    register_url_convertor("any_trie_test", AnythingConvertor())
+    try:
+        trie, _ = build(["/a/{x:any_trie_test}"])
+        assert trie.always == [0]
+        assert_superset(["/a/{x:any_trie_test}"], ["/a/b", "/a/b/c"])
+    finally:
+        convertors.CONVERTOR_TYPES.pop("any_trie_test", None)
+
+
+def test_websocket_routes_are_indexed() -> None:
+    trie = RouteTrie()
+    route = WebSocketRoute("/ws/{room}", ws_endpoint)
+    trie.add(0, route.path, route.param_convertors)
+    assert trie.match_all("/ws/lobby") == [0]
+    assert trie.match_all("/ws") == []
+
+
+def test_duplicate_paths_keep_registration_order() -> None:
+    trie, _ = build(["/items/", "/items/", "/{x}/"])
+    assert trie.match_all("/items/") == [0, 1, 2]
+
+
+def test_mounts_and_hosts_are_always_candidates() -> None:
+    routes: list[BaseRoute] = [
+        Mount("/mounted", routes=[Route("/inner", named("inner"))]),
+        Host("api.example.org", app=Router()),
+        Route("/x", named("x")),
+    ]
+    lookup = TrieRouteLookup(routes)
+    scope = {"type": "http", "method": "GET", "path": "/anything", "root_path": "", "headers": []}
+
+    assert lookup.candidates(scope) == [routes[0], routes[1]]
+
+
+def test_route_subclasses_are_always_candidates() -> None:
+    class HeaderRoute(Route):
+        pass
+
+    routes: list[BaseRoute] = [HeaderRoute("/x", named("x")), Route("/y", named("y"))]
+    lookup = TrieRouteLookup(routes)
+    scope = {"type": "http", "method": "GET", "path": "/y", "root_path": "", "headers": []}
+
+    assert lookup.candidates(scope) == routes
+
+
+# --- Contract ---------------------------------------------------------------
+
+
+def test_conformance() -> None:
+    assert_route_lookup_conformance(TrieRouteLookup)
+
+
+def test_narrows_the_conformance_route_table() -> None:
+    # The suite is only meaningful if the trie actually narrows.
+    lookup = TrieRouteLookup(CONFORMANCE_ROUTES)
+    scope = {"type": "http", "method": "GET", "path": "/users/42", "root_path": "", "headers": []}
+
+    assert len(lookup.candidates(scope)) < len(CONFORMANCE_ROUTES)
+
+
+CONVERTOR_SUFFIXES = ["", ":int", ":float", ":uuid", ":str", ":path"]
+STATIC_SEGMENTS = ["api", "v1", "users", "items", "orders", "me", "bulk", "files", "static"]
+PROBE_SEGMENTS = STATIC_SEGMENTS + [
+    "42",
+    "abc",
+    "25.5",
+    "EC38DF32-CEDA-4CFA-9B4A-1AEB94AD551A",
+    "ec38df32ceda4cfa9b4a1aeb94ad551a",
+    "a-b",
+    "deadbeef",
+    "v7",
+    "bob:disable",
+]
+
+
+def _corpus(size: int, rng: random.Random) -> list[str]:
+    paths: set[str] = set()
+    while len(paths) < size:
+        parts: list[str] = []
+        used = 0
+        for _ in range(rng.randint(1, 5)):
+            kind = rng.choices(["static", "param", "typed", "compound", "path"], weights=[5, 3, 2, 2, 1])[0]
+            if kind == "static":
+                parts.append(rng.choice(STATIC_SEGMENTS))
+            elif kind == "param":
+                parts.append("{p%d}" % used)
+            elif kind == "typed":
+                parts.append("{p%d%s}" % (used, rng.choice(CONVERTOR_SUFFIXES)))
+            elif kind == "compound":
+                parts.append(rng.choice(["v{p%d:int}", "{p%d}:disable", "files({p%d:int})", "x{p%d:path}"]) % used)
+            else:
+                parts.append("{p%d:path}" % used)
+            used += 1
+            if parts[-1].endswith(":path}"):
+                break
+        paths.add("/" + "/".join(parts) + ("/" if rng.random() < 0.4 else ""))
+    return sorted(paths)
+
+
+@pytest.mark.parametrize("seed", range(25))
+def test_differential_fuzz_against_path_regex(seed: int) -> None:
+    """A dropped candidate is a silent 404, so prove the superset property against
+    Starlette's own `path_regex` over randomised route tables and paths.
+    """
+    rng = random.Random(seed)
+    paths = _corpus(40 + seed * 8, rng)
+    trie, routes = build(paths)
+
+    for _ in range(2000):
+        probe = "/" + "/".join(rng.choice(PROBE_SEGMENTS) for _ in range(rng.randint(1, 6)))
+        if rng.random() < 0.4:
+            probe += "/"
+        oracle = {index for index, route in enumerate(routes) if route.path_regex.match(probe)}
+        dropped = oracle - set(trie.match_all(probe))
+        assert not dropped, f"seed={seed} {probe!r} dropped {[paths[index] for index in dropped]}"
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_differential_fuzz_uses_the_conformance_oracle(seed: int) -> None:
+    rng = random.Random(1000 + seed)
+    paths = _corpus(60, rng)
+    probes = [
+        "/"
+        + "/".join(rng.choice(PROBE_SEGMENTS) for _ in range(rng.randint(1, 5)))
+        + ("/" if rng.random() < 0.4 else "")
+        for _ in range(100)
+    ]
+    routes = [Route(path, named(f"r{index}")) for index, path in enumerate(paths)]
+
+    assert_route_lookup_conformance(TrieRouteLookup, routes=routes, paths=probes + CONFORMANCE_PATHS)
+
+
+# --- End to end -------------------------------------------------------------
+
+
+def test_dispatch_end_to_end() -> None:
+    app = Starlette(
+        routes=[
+            Route("/", named("root")),
+            Route("/users/me", named("me")),
+            Route("/users/{user_id:int}", named("user")),
+            Route("/only-post", named("only-post"), methods=["POST"]),
+            Route("/trailing/", named("trailing")),
+            Route("/static/{path:path}", named("static")),
+            WebSocketRoute("/ws/{room}", ws_endpoint),
+            Mount("/mounted", routes=[Route("/inner", named("inner"))]),
+            Host("api.example.org", app=Router(routes=[Route("/hosted", named("hosted"))])),
+        ]
+    )
+    app.route_lookup_factory = TrieRouteLookup
+    client = TestClient(app)
+
+    assert client.get("/").text == "root {}"
+    assert client.get("/users/me").text == "me {}"
+    assert client.get("/users/42").text == "user {'user_id': 42}"
+    assert client.get("/static/a/b.txt").text == "static {'path': 'a/b.txt'}"
+    assert client.get("/mounted/inner").text == "inner {}"
+    assert client.get("http://api.example.org/hosted").text == "hosted {}"
+    assert client.get("/missing").status_code == 404
+
+    response = client.get("/only-post")
+    assert response.status_code == 405
+    assert response.headers["allow"] == "POST"
+
+    response = client.get("/trailing", follow_redirects=False)
+    assert response.status_code == 307
+
+    with client.websocket_connect("/ws/lobby") as websocket:
+        assert websocket.receive_text() == "ws"
+
+
+def test_dispatch_under_root_path() -> None:
+    app = Starlette(routes=[Route("/", named("root")), Route("/users/{id}", named("user"))])
+    app.route_lookup_factory = TrieRouteLookup
+    client = TestClient(app, root_path="/sub")
+
+    assert client.get("/sub/users/7").text == "user {'id': '7'}"
+    # `path == root_path`, so the router matches against an empty route path and
+    # falls through to the trailing-slash redirect, same as the linear scan.
+    assert client.get("/sub", follow_redirects=False).status_code == 307
+    assert client.get("/sub").text == "root {}"
+    assert client.get("/sub/").text == "root {}"
+
+
+def test_lookup_survives_route_changes() -> None:
+    app = Starlette(routes=[Route("/a", named("a"))])
+    app.route_lookup_factory = TrieRouteLookup
+    client = TestClient(app)
+
+    assert client.get("/a").text == "a {}"
+    app.routes.append(Route("/b", named("b")))
+    assert client.get("/b").text == "b {}"
+
+
+def test_trie_is_rebuilt_per_router() -> None:
+    subapp = Starlette(routes=[Route("/inner", lambda request: PlainTextResponse("inner"))])
+    app = Starlette(routes=[Mount("/sub", app=subapp)])
+    app.route_lookup_factory = TrieRouteLookup
+
+    with TestClient(app) as client:
+        assert isinstance(subapp.router.route_lookup, TrieRouteLookup)
+        assert client.get("/sub/inner").text == "inner"


### PR DESCRIPTION
## Summary

Adds `TrieRouteLookup`, a pure-Python segment trie built on the `RouteLookup`
extension point from #3394. Opt-in, no new dependency:

```python
from starlette.routing import TrieRouteLookup

app.route_lookup_factory = TrieRouteLookup
```

Inspired by [`jirikuncar/ffroute`](https://github.com/jirikuncar/ffroute), and
shaped so that swapping in its Rust core later means replacing only the adapter:
`starlette/_trie.py` is a pure index over `(path, convertors)` that knows nothing
about `Route`, and `TrieRouteLookup` in `routing.py` does the Starlette-side type
checks.

> [!NOTE]
> Based on #3394. Review that one first; this PR targets its branch, so the diff
> here is only the trie.

## How it works

The trie returns a *superset* of the routes whose `path_regex` could match, in
registration order. `Route.matches()` still runs on each candidate, so the trie
never decides a match on its own. Everything is preserved: first-registered-wins,
405s, `redirect_slashes`, `Mount`, `Host`, WebSockets, param extraction, custom
convertors.

`Route` and `WebSocketRoute` are indexed by path. `Mount`, `Host`, route
subclasses, and any segment the trie cannot represent exactly are always-candidates.

**Custom convertors stay indexed when provably slash-free.** Rather than probing
with sample strings, `_pattern_may_match_slash()` scans the regex source
(character classes, ranges, escapes). `[a-z0-9-]+` is indexed; `.*`, `\S`, `\x2f`,
`[^a]` and anything unparseable fall back to always-candidate. Conservative in the
safe direction, so apps with custom convertors keep the fast path.

**Exact type checks, not `isinstance`.** A `Route` subclass overriding `matches()`
can match paths its own `path` never describes, which `isinstance` would silently
break.

Both issues reviewers found on #3339 are handled by construction: convertor
regexes are wrapped in `(?:...)` so alternation keeps segment-local precedence,
and a `path` convertor inside a compound segment such as `/files-{p:path}` is
detected as slash-capable.

## Safety

A dropped candidate is a silent 404, so:

* 25-seed differential fuzz against Starlette's own `Route.path_regex`, 2000
  probes per seed over randomised corpora
* the `StrictRouteLookup` conformance suite from #3394
* a test asserting the trie actually narrows, so the conformance run cannot pass
  trivially
* targeted cases: uuid casing and dashless forms, `:path`, compound segments,
  intra-segment literals, alternation convertors, slash-capable convertors,
  `root_path`, mounts, hosts, WebSockets, 405s, redirects

`starlette/_trie.py` is at 100% statement and branch coverage.

## Benchmarks

Reproduce with `uv run python scripts/bench_route_lookup.py`.

Apple M-series, CPython 3.14.5, REST-shaped route tables, best-of-5 over a
workload that visits every route once, so the linear scan is measured at its
average position rather than its best or worst. `linear / trie`:

| routes | dispatch hit us | x | dispatch miss us | x | resolve hit ns | x | resolve miss ns | x | build ms |
|---|---|---|---|---|---|---|---|---|---|
| 5 | 3.7 / 4.3 | 0.9x | 3.7 / 2.4 | 1.6x | 1158 / 1625 | 0.7x | 1025 / 400 | 2.6x | 0.01 |
| 20 | 5.2 / 4.2 | 1.2x | 9.3 / 2.4 | 3.9x | 2623 / 1610 | 1.6x | 3835 / 367 | 10.5x | 0.04 |
| 50 | 8.4 / 4.2 | 2.0x | 20.4 / 2.4 | 8.6x | 5557 / 1703 | 3.3x | 9418 / 397 | 23.7x | 0.10 |
| 200 | 23.4 / 4.4 | 5.4x | 76.1 / 2.4 | 31.6x | 20819 / 1744 | 11.9x | 37915 / 389 | 97.4x | 0.40 |
| 740 | 78.2 / 4.5 | 17.4x | 277.9 / 2.3 | 118.5x | 75043 / 1653 | 45.4x | 142712 / 386 | 369.7x | 1.49 |
| 2000 | 208.5 / 4.4 | 47.4x | 756.2 / 2.4 | 317.2x | 203833 / 1670 | 122.1x | 391925 / 374 | 1046.8x | 4.33 |

**dispatch** is a full request through `Router.__call__` with an async endpoint.
**resolve** is the routing decision alone (candidate selection plus `matches()`
until a match). **build** is one-time trie construction.

Reading it honestly:

* Dispatch time is flat for the trie (4.2-4.5 us) and linear for the scan. The
  O(N) factor is gone.
* Misses benefit most: the trie stops at the first dead segment, the scan runs
  every regex before concluding 404. At 740 routes a miss costs 386 ns instead of
  143 us.
* **At 5 routes the trie is slightly slower on hits** (0.7x resolve, 0.9x
  dispatch). The crossover is around 10-20 routes. That is why this is opt-in.
* Trie hit cost is dominated by `Route.matches()`, not the lookup: miss resolve
  (~390 ns) is roughly the pure lookup cost, while hit resolve (~1.7 us) includes
  the two or three `matches()` calls the trie still hands to Starlette. A native
  lookup only attacks the ~390 ns part, so on hits it cannot beat this by anything
  like the 100x its own micro-benchmarks show.
* Build cost is small and roughly linear: 1.5 ms at 740 routes, well under the
  regex compilation those routes already pay at construction.

These numbers are not comparable to the table in #3339: that harness had a sync
endpoint, and the threadpool hop alone put a constant ~68 us floor under every
measurement.

## Incidental fix

`tests/test_convertors.py`'s teardown rebound `convertors.CONVERTOR_TYPES` to a
copy, which permanently desynced `routing`'s by-value import. Changed to restore
in place. Same latent bug #3339 hit; it surfaced here as three failures in the
custom-convertor trie tests when the full suite ran.

## Open question

`TrieRouteLookup` is opt-in here. The 5-route row argues for keeping it that way;
the 740-route row argues for eventually making it the default. That decision is
independent of both PRs and can be made later without an API change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed
and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

