### PR TITLE
fix: reject empty byte ranges in FileResponse

### DIFF
--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -474,8 +474,7 @@ class FileResponse(Response):
         if any(not (0 <= start < file_size) for start, _ in ranges):
             raise RangeNotSatisfiable(file_size)
 
-        # Half-open ranges: empty ranges (start == end) are unsatisfiable, e.g. bytes=5-4
-        # parses to (5, 5). One-byte range bytes=5-5 parses to (5, 6). Issue #3388.
+        # An empty half-open range is not a valid range.
         if any(start >= end for start, end in ranges):
             raise MalformedRangeHeader("Range header: start must be less than end")
 

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -474,7 +474,9 @@ class FileResponse(Response):
         if any(not (0 <= start < file_size) for start, _ in ranges):
             raise RangeNotSatisfiable(file_size)
 
-        if any(start > end for start, end in ranges):
+        # Half-open ranges: empty ranges (start == end) are unsatisfiable, e.g. bytes=5-4
+        # parses to (5, 5). One-byte range bytes=5-5 parses to (5, 6). Issue #3388.
+        if any(start >= end for start, end in ranges):
             raise MalformedRangeHeader("Range header: start must be less than end")
 
         if len(ranges) == 1:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -810,10 +810,17 @@ def test_file_response_range_must_be_requested(file_response_client: TestClient)
     assert response.text == "Range header: range must be requested"
 
 
-def test_file_response_start_must_be_less_than_end(file_response_client: TestClient) -> None:
-    response = file_response_client.get("/", headers={"Range": "bytes=100-0"})
+@pytest.mark.parametrize("header", ["bytes=5-4", "bytes=0--1", "bytes=0-1, 5-4"])
+def test_file_response_empty_range(file_response_client: TestClient, header: str) -> None:
+    response = file_response_client.get("/", headers={"Range": header})
     assert response.status_code == 400
     assert response.text == "Range header: start must be less than end"
+
+
+def test_file_response_single_byte_range(file_response_client: TestClient) -> None:
+    response = file_response_client.get("/", headers={"Range": "bytes=5-5"})
+    assert response.status_code == 206
+    assert response.headers["content-length"] == "1"
 
 
 def test_file_response_merge_ranges(file_response_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
`FileResponse._parse_range_header` accepted empty half-open ranges such as `bytes=5-4` → `(5, 5)`, producing a malformed 206. One-byte `bytes=5-5` → `(5, 6)` is unaffected.

## Change
Reject ranges with `start >= end` instead of `start > end`.

Fixes #3388


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

