### PR TITLE
perf: skip redundant work in QueryParams construction

### DIFF
--- a/starlette/datastructures.py
+++ b/starlette/datastructures.py
@@ -375,6 +375,24 @@ class MultiDict(ImmutableMultiDict[Any, Any]):
         self._dict.update(value)
 
 
+def _parse_query_string(query: str) -> list[tuple[str, str]]:
+    """Equivalent to ``parse_qsl(query, keep_blank_values=True)``.
+
+    ``parse_qsl`` unconditionally runs both halves of every field through
+    ``unquote_plus``. When the query string contains no ``%`` and no ``+`` there
+    is nothing to decode, so the split is all the work that is needed.
+    """
+    if "%" in query or "+" in query:
+        return parse_qsl(query, keep_blank_values=True)
+
+    items = []
+    for field in query.split("&"):
+        if field:
+            key, _, value = field.partition("=")
+            items.append((key, value))
+    return items
+
+
 class QueryParams(ImmutableMultiDict[str, str]):
     """
     An immutable multidict.
@@ -388,6 +406,16 @@ class QueryParams(ImmutableMultiDict[str, str]):
         assert len(args) < 2, "Too many arguments."
 
         value = args[0] if args else []
+
+        if isinstance(value, (str, bytes)) and not kwargs:
+            # A query string always yields str keys and str values, so the
+            # normalisation below is a no-op on this path. It is still required
+            # when kwargs are present, because those values may be any type.
+            query = value.decode("latin-1") if isinstance(value, bytes) else value
+            items = _parse_query_string(query)
+            self._list = items
+            self._dict = dict(items)
+            return
 
         if isinstance(value, str):
             super().__init__(parse_qsl(value, keep_blank_values=True), **kwargs)

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -369,6 +369,26 @@ def test_queryparams() -> None:
     assert QueryParams(q) == q
 
 
+def test_queryparams_empty_fields() -> None:
+    assert QueryParams("a=1&&b=2") == QueryParams("a=1&b=2")
+    assert QueryParams("&") == QueryParams()
+    assert QueryParams("a") == QueryParams([("a", "")])
+    assert QueryParams("=v") == QueryParams([("", "v")])
+
+
+def test_queryparams_keyword_arguments() -> None:
+    """Keyword-argument values are not necessarily strings, and are normalised.
+
+    A query string on its own always yields str keys and values, but kwargs are
+    merged in by ImmutableMultiDict and may be any type.
+    """
+    assert QueryParams("a=1", b=2) == QueryParams([("a", "1"), ("b", "2")])
+    assert QueryParams(b"a=1", b=2) == QueryParams([("a", "1"), ("b", "2")])
+    assert QueryParams(a=1) == QueryParams([("a", "1")])
+    assert dict(QueryParams("a=1", b=2)) == {"a": "1", "b": "2"}
+    assert QueryParams("a=1", a=2) == QueryParams([("a", "1"), ("a", "2")])
+
+
 @pytest.mark.anyio
 async def test_upload_file_file_input() -> None:
     """Test passing file/stream into the UploadFile constructor"""


### PR DESCRIPTION
# Summary

`QueryParams.__init__` does two pieces of work that the query-string path doesn't need.

It hands the string to `ImmutableMultiDict.__init__`, which builds `_list` and `_dict`, and then rebuilds both:

```python
self._list = [(str(k), str(v)) for k, v in self._list]
self._dict = {str(k): str(v) for k, v in self._dict.items()}
```

`parse_qsl` already returns `str` keys and `str` values, so on that path this is three container builds and 4N `str()` calls where one list and one dict would do.

Separately, `parse_qsl` runs both halves of every field through `unquote_plus`. If the query string has no `%` and no `+`, there's nothing to decode and the split is all the work needed.

So this adds a fast path for `str`/`bytes` input with no keyword arguments, plus a `_parse_query_string` helper that falls back to `parse_qsl` whenever the string really does need decoding.

The `str()` normalisation stays where it earns its keep. `QueryParams("a=1", b=2)` goes through `ImmutableMultiDict`, which merges keyword-argument values of any type, so the fast path only triggers when `kwargs` is empty. I got this wrong in an early draft and the round trip through `QueryParams(a=1)` caught it.

# Measurements

Python 3.12.13, stock defaults, nothing tuned to produce these numbers.

Per call, medians of 7 repetitions of 60,000 iterations:

| query string | before | after | |
|---|---:|---:|---:|
| empty | 964 ns | 509 ns | 1.90x |
| `page=12` | 2006 ns | 731 ns | 2.74x |
| `limit=10&offset=20&sort=name&filter=active&q=term` | 5021 ns | 1367 ns | 3.67x |
| `q=hello+world&path=%2Fa%2Fb` | 4772 ns | 4079 ns | 1.17x |
| 20 fields | 17118 ns | 4225 ns | 4.05x |

Over a mixed workload of 12 query strings weighted toward the small end, 20,000 iterations, 9 interleaved repetitions, medians: **57.445 us to 25.815 us, 2.23x**.

I also counted instructions with Callgrind, since the box was busy and wall time on a shared machine isn't worth much: **60.67M to 26.49M user-space instructions retired per corpus pass, a 56.3% reduction**. The search that produced this is at https://dashboard.weco.ai/share/0S8Z_9mSbPijzsrfPdlCvwOH_KLR4hH9

# What this doesn't claim

The denominator here is narrow.

`Request.query_params` is a lazy property that caches into `self._query_params`, and `starlette/requests.py:141` is the only place in the library that builds a `QueryParams` from `scope["query_string"]`. This isn't work every request pays. It's paid at most once per request, and only when a handler or middleware actually reads `request.query_params`.

For scale: a request driven straight through the ASGI callable, no server and no socket, costs about 30 us of Starlette's own CPU. On a five-field query string this takes roughly 3.7 us off that, for the requests that read query parameters at all.

Percent-encoded and plus-encoded query strings still go through `parse_qsl` and only gain the normalisation saving, which is the 1.17x row.

# Tests

`tests/` passes: 981 passed, 2 xfailed. `main` is 979 passed, 2 xfailed; the two extra are the ones added here. `scripts/check` is clean, and `scripts/coverage` still reports 100%.

The coverage gate is what caught the gap: the fast path left three branches untested, including both keyword-argument paths, which the suite had never exercised because every `str`/`bytes` construction used to reach them.

I also diffed behaviour against an unmodified copy of `datastructures.py` over blank values, repeated keys, fields with no `=`, empty fields, `;` in values, raw latin-1 bytes, truncated and invalid percent escapes, non-ASCII escapes, both `str` and `bytes` input, mapping and item-list input, non-`str` values, and every keyword-argument combination, plus 220 generated query strings per run. That compares `multi_items()`, the dict view, `getlist`, `str()`, `repr()`, `len()`, containment, `__getitem__`, `get`, iteration and equality, and it covers `MultiDict` and `FormData` too, since they share `ImmutableMultiDict.__init__`.
