### PR TITLE
Add GZipMiddleware benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,36 +6,32 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   benchmarks:
-    name: GZip benchmarks
-    runs-on: ubuntu-24.04
+    name: Run benchmarks
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           persist-credentials: false
-
-      # CodSpeed's tracing instrument requires setup-python rather than a Python
-      # installation managed by uv.
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
-        with:
-          python-version: "3.14.5"
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
+          python-version: "3.13"
           enable-cache: true
 
       - name: Install dependencies
         run: scripts/install
+        shell: bash
 
-      - name: Run benchmarks
+      - name: Run the benchmarks
         uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
         with:
           run: uv run pytest benchmarks/gzip_benchmark.py --codspeed

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,42 @@
+---
+name: CodSpeed
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    name: GZip benchmarks
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # CodSpeed's tracing instrument requires setup-python rather than a Python
+      # installation managed by uv.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
+        with:
+          python-version: "3.14.5"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: scripts/install
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@0ca9cbbf4623b599a6c3ed4fc8a922942705d9f1 # v5.0.2
+        with:
+          run: uv run pytest benchmarks/gzip_benchmark.py --codspeed
+          mode: simulation,memory

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,20 @@
+# Benchmarks
+
+The gzip benchmark exercises Starlette's `GZipResponder` with deterministic
+payloads representing valid JSON, repetitive text, and incompressible bytes.
+
+It compares levels 1 through 9 at 1 MiB. It also compares representative levels
+1, 6, and 9 at 32 KiB, 256 KiB, 5 MiB, and 10 MiB. This keeps the suite useful
+for detecting payload-size regressions without running the full Cartesian
+product of every level and large size.
+
+Run it locally with:
+
+```console
+uv run pytest benchmarks/gzip_benchmark.py --codspeed
+```
+
+Payload construction and decompression validation are outside the measured
+region. Each case creates only one input payload, so the largest case does not
+leave all benchmark inputs resident in memory. CodSpeed CI records simulated
+CPU performance, peak heap usage, and allocation counts.

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+from pytest_codspeed.plugin import BenchmarkFixture
+
+from starlette.middleware.gzip import GZipResponder
+from starlette.types import Receive, Scope, Send
+
+KiB = 1024
+MiB = 1024 * KiB
+
+PayloadKind = Literal["json", "text", "incompressible"]
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    payload_kind: PayloadKind
+    size: int
+    level: int
+
+    @property
+    def id(self) -> str:
+        size = f"{self.size // MiB}MiB" if self.size >= MiB else f"{self.size // KiB}KiB"
+        return f"{self.payload_kind}-{size}-level-{self.level}"
+
+
+# All compression levels are compared at 1 MiB. The size curve uses three
+# representative levels so that the suite still reaches 10 MiB without making
+# every CI run exercise the full large-payload Cartesian product.
+PAYLOAD_KINDS: tuple[PayloadKind, ...] = ("json", "text", "incompressible")
+CASES = tuple(
+    BenchmarkCase(payload_kind, MiB, level) for payload_kind in PAYLOAD_KINDS for level in range(1, 10)
+) + tuple(
+    BenchmarkCase(payload_kind, size, level)
+    for payload_kind in PAYLOAD_KINDS
+    for size in (32 * KiB, 256 * KiB, 5 * MiB, 10 * MiB)
+    for level in (1, 6, 9)
+)
+
+
+async def unused_app(scope: Scope, receive: Receive, send: Send) -> None:
+    raise AssertionError("The benchmark calls GZipResponder directly")
+
+
+def make_json_payload(size: int) -> bytes:
+    """Build a deterministic, valid JSON document of exactly ``size`` bytes."""
+    prefix = b'{"requests":['
+    padding_prefix = b'],"padding":"'
+    suffix = b'"}'
+    output = io.BytesIO()
+    output.write(prefix)
+
+    index = 0
+    while True:
+        row = json.dumps(
+            {
+                "id": index,
+                "timestamp": f"2026-08-04T12:{index % 60:02d}:{index * 7 % 60:02d}.{index * 997 % 1000:03d}Z",
+                "method": ("GET", "POST", "PATCH", "DELETE")[index % 4],
+                "path": f"/api/v1/projects/{index % 1_009}/events/{index * 17 % 65_537}",
+                "status": (200, 201, 204, 400, 404, 409, 422, 500)[index % 8],
+                "duration_ms": round((index * 37 % 10_000) / 100, 2),
+                "request_id": f"{index * 0x9E3779B97F4A7C15 % (1 << 128):032x}",
+                "message": ("request completed", "validation failed", "resource updated")[index % 3],
+            },
+            separators=(",", ":"),
+        ).encode()
+        separator = b"," if index else b""
+        required_tail = len(padding_prefix) + len(suffix)
+        if output.tell() + len(separator) + len(row) + required_tail > size:
+            break
+        output.write(separator)
+        output.write(row)
+        index += 1
+
+    output.write(padding_prefix)
+    output.write(b"x" * (size - output.tell() - len(suffix)))
+    output.write(suffix)
+    payload = output.getvalue()
+    assert len(payload) == size
+    return payload
+
+
+def make_text_payload(size: int) -> bytes:
+    paragraph = (
+        b"Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python. "
+        b"It is production-ready and gives you the following: seriously impressive performance, WebSocket support, "
+        b"in-process background tasks, startup and shutdown events, and a test client built on HTTPX.\n"
+    )
+    return (paragraph * (size // len(paragraph) + 1))[:size]
+
+
+def make_payload(kind: PayloadKind, size: int) -> bytes:
+    if kind == "json":
+        return make_json_payload(size)
+    if kind == "text":
+        return make_text_payload(size)
+    # SHAKE provides deterministic high-entropy bytes without keeping another
+    # 10 MiB random-data buffer alive alongside the returned payload.
+    return hashlib.shake_256(b"starlette-gzip-benchmark-v1").digest(size)
+
+
+def compress(payload: bytes, level: int) -> bytes:
+    responder = GZipResponder(unused_app, minimum_size=0, compresslevel=level)
+    with responder.gzip_buffer, responder.gzip_file:
+        return responder.apply_compression(payload, more_body=False)
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=10)
+def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
+    # Payload construction is intentionally outside the measured region. Cases
+    # are function-scoped, so only one source payload is resident at a time.
+    payload = make_payload(case.payload_kind, case.size)
+    compressed = benchmark(compress, payload, case.level)
+
+    assert gzip.decompress(compressed) == payload
+    benchmark.extra_info["input_bytes"] = len(payload)
+    benchmark.extra_info["output_bytes"] = len(compressed)
+    benchmark.extra_info["compression_ratio"] = len(compressed) / len(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "coverage>=7.8.2",
     "importlib-metadata==9.0.0",
     "mypy==2.1.0",
+    "pytest-codspeed==5.0.3",
     "ruff==0.15.19",
     "types-PyYAML==6.0.12.20250516",
     "pytest==9.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "coverage>=7.8.2",
     "importlib-metadata==9.0.0",
     "mypy==2.1.0",
-    "pytest-codspeed==5.0.3",
+    "pytest-codspeed>=4.1.1",
     "ruff==0.15.19",
     "types-PyYAML==6.0.12.20250516",
     "pytest==9.1.1",

--- a/scripts/check
+++ b/scripts/check
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-export SOURCE_FILES="starlette tests"
+export SOURCE_FILES="starlette tests benchmarks"
 
 set -x
 

--- a/uv.lock
+++ b/uv.lock
@@ -1141,6 +1141,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-codspeed"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/cf932fcd1960a2fd6d9b09eb403253a8709aeee975961afa6299239a830e/pytest_codspeed-5.0.3.tar.gz", hash = "sha256:91afef90e6a96b013495e4702ef5d6358614a449e71008cdc194ef668778b92f", size = 324571, upload-time = "2026-05-22T16:20:49.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f5/a8f70147216e4b84046ca406d03ecc8e83e3ea56ba1bdca0bb79cca79fee/pytest_codspeed-5.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:005348ea52ace3ede2e2f595913912ad2564cca7b124211a88dc78a9cb1fca63", size = 366249, upload-time = "2026-05-22T16:20:39.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/bd/7a4dbcf457fcc3ed788c55d402f3af2671e0e342b6098090fd590aa8712e/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbe6a4a00b449b6ba2771f644cbc38bdf55acf5c812e60e5659110e19dd9f510", size = 932229, upload-time = "2026-05-22T16:20:37.283Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/414ea4c66559f24ec06aeb6db62bfc7079582dac1452e648affe1eb5cfb4/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ac4344f34bbcdd17f6f8c30dbac3da2f80d223dd112e568fd7f7c2cd4cbc693", size = 934647, upload-time = "2026-05-22T16:20:31.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ef/32ce60d42a4aa43e728d988e13eb6568fbc7b10a514517b459bafd3f2b94/pytest_codspeed-5.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f56d0339cd98d26f6e561987be25bdd2761a5d53d8f73493b1ebe02d0d451093", size = 366253, upload-time = "2026-05-22T16:21:10.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/15/c66ef90a793c5d2c039e63a1726a5e55c678be2618b0f5f1660d0f79e25f/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c682f6645d4eb472f3bd95dbda1805e3af4243610572cb7d6bf94a88e8a0b6c", size = 932465, upload-time = "2026-05-22T16:20:34.265Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7b/d231279301967f05b7909160489e85ee3a1b9da76094ea25343faba1abc2/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f852bee785a7a124cb1720b1915670c6742af87747dc4d838f3ffdbd365ce9d9", size = 934925, upload-time = "2026-05-22T16:20:47.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/22/456c48160b761d5028c8afa119f085a9fc42855a783a13d73918078969f0/pytest_codspeed-5.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2eeb25fb1ac3f73c4de50e739e78fea396b89782bdb740bf2a7cd2df21f8d4ee", size = 366255, upload-time = "2026-05-22T16:20:56.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/33/ac7441fa937c9d9f158083a8c46920a5a5c81ed3c5f96240fc8d650db5c2/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73c5c9d98a3372a42611989ccfa437cce3842431ac6d6b9ab42c4f0e59c070f7", size = 932325, upload-time = "2026-05-22T16:21:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bc/8b994adcb9e9016e7d9a808056a3dd9cca21441e432ef456eae2b697d7fe/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2e0ab65df73e837666d12357280ca50ff6d6ac03ea5266703be518b68170edf", size = 934885, upload-time = "2026-05-22T16:21:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4", size = 366253, upload-time = "2026-05-22T16:20:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7b/ae76fd8ac656b9695806a6aafd5f22ec32e6ce20e266a58f9112e01d3cd8/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c383c9121deb58a69f174188e9e4488ffc0daced0ed276abf87747182511901", size = 932360, upload-time = "2026-05-22T16:20:30.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c", size = 934928, upload-time = "2026-05-22T16:20:38.62Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6a/fdcec19c7f267c195f147c51d3fd2245f6b8d09b80495ed0a90c008e0842/pytest_codspeed-5.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25464363c7f9b9bd5022e969c0addba616fa40ac9b8f0fc9e030c4538863b32d", size = 366259, upload-time = "2026-05-22T16:21:06.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/96/c6b03b81dcd21ae3d6b32cca0b3c10149fa378eb21b338d4b63c9eb8050b/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efd43f82ea03ced8488a767ded9473f050791ab7783ea8654107e1e0ac66af40", size = 932395, upload-time = "2026-05-22T16:21:04.804Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/56ad8f1cc7d6962f8a680141b361e93467a2abc53d976cd9d5e1edd740e3/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:782f9985b6f6b45b8bc20152d206d3a52b56dd088ba81cb70a71f0b39841be9e", size = 934994, upload-time = "2026-05-22T16:20:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/54/9096c4545f09da94b1b00f3be2fe4952949e86c9bcafca9a29b26aed1a75/pytest_codspeed-5.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9aa0815b90196f3c20d736ea8691381e97f12bbe8c7d87af10a351e434b452cb", size = 366311, upload-time = "2026-05-22T16:20:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/3c/24c53f67a38ad48cb087105ac30a8aa0923223ee274ea9bf2dc705edaa59/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85505c96a3477c346ec2d2b7dced8478f4c651e2b1666ee102d53a832b511853", size = 933169, upload-time = "2026-05-22T16:20:43.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/de/2213f868fa7694f743f96cccbc07e757f45c920c523cccc2da97bc8652df/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20eba63765be9d1b6cacbbfad84b87d49eb04b357a7045a0899880da181f81e3", size = 935522, upload-time = "2026-05-22T16:21:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/5dfea1c031d6cccc11653464828edf205c30f798caf5b2a85375aacd914a/pytest_codspeed-5.0.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:ec9fa6f0af0a9feb0e0bd517fb59ef28f806fbd50c0c6900ac26cbb4d080eba5", size = 366275, upload-time = "2026-05-22T16:20:59.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2b/af4d1b612f03b98a6cf3c7d5f62678917a60110a8bf380d49ab408b31137/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8df77b3409f54f4a268f77f3ff74992fe1d995cdbaf2cecf8ad74d32db217ce7", size = 932537, upload-time = "2026-05-22T16:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a2/c7ec45e36a61b418efb2a3cccaa67a0c2fcf1f21d5880f64c33114f0c249/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d8695a227ea1c3a41d25db5b3fe720bf1b4808bd38862be811a4efd902c792", size = 934153, upload-time = "2026-05-22T16:21:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c7/d5bada9618a0af56a5c8065fc61280849cab8e7c1e24025807a51c3157ce/pytest_codspeed-5.0.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bf4cc4178cbace8f4d2bd240408276bc4da3850ac5fcb5fb5f8a74ab417615bb", size = 366339, upload-time = "2026-05-22T16:20:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/fb27aeb40a81320e7349553b877a21333c897b27c8dfe215630452908f36/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abe793da40f87295d33988673d34f06ea569848b44490b847552cd416816258a", size = 933055, upload-time = "2026-05-22T16:20:44.861Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/6f2d69e96deaf0475a695fc9195af59e7a3b5fab50782855e65c63a7bc28/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3a9ed38dfa776443b86f4b49a982e8443d0953db4974bd2673d63cc904ae1ad", size = 934481, upload-time = "2026-05-22T16:20:58.264Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b2/1d2a993c532146dce9eca5b5942d51898021c3579ce18b2454f932a915f8/pytest_codspeed-5.0.3-py3-none-any.whl", hash = "sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378", size = 74033, upload-time = "2026-05-22T16:20:26.814Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1438,6 +1475,7 @@ dev = [
     { name = "importlib-metadata" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-codspeed" },
     { name = "ruff" },
     { name = "starlette", extra = ["full"] },
     { name = "trio" },
@@ -1471,6 +1509,7 @@ dev = [
     { name = "importlib-metadata", specifier = "==9.0.0" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-codspeed", specifier = "==5.0.3" },
     { name = "ruff", specifier = "==0.15.19" },
     { name = "starlette", extras = ["full"] },
     { name = "trio", specifier = "==0.33.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1509,7 +1509,7 @@ dev = [
     { name = "importlib-metadata", specifier = "==9.0.0" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "pytest", specifier = "==9.1.1" },
-    { name = "pytest-codspeed", specifier = "==5.0.3" },
+    { name = "pytest-codspeed", specifier = ">=4.1.1" },
     { name = "ruff", specifier = "==0.15.19" },
     { name = "starlette", extras = ["full"] },
     { name = "trio", specifier = "==0.33.0" },


### PR DESCRIPTION
## Summary

- add deterministic GZipResponder benchmarks for realistic JSON, repetitive text, and incompressible data
- compare compression levels 1–9 at 1 MiB and representative levels across 32 KiB–10 MiB
- record input size, compressed size, compression ratio, simulated CPU performance, and memory allocations
- run the suite with CodSpeed in simulation and memory modes

## Rationale

Changes to GZipMiddleware need reproducible data across payload types, compression levels, response sizes, and memory use. The benchmark matrix covers those dimensions while constructing one payload per case so large inputs are not retained together.

The benchmark file is deliberately named outside pytest's default test discovery pattern, so the regular test suite does not allocate 10 MiB payloads. This PR does not change runtime middleware behavior.

## Validation

- `scripts/check`
- `pytest benchmarks/gzip_benchmark.py -q` — 63 passed
- `pytest benchmarks/gzip_benchmark.py --codspeed -q -k '10MiB'` — 9 benchmarked
- valid JSON payload verification through 10 MiB
- Zizmor workflow audit
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

