### PR TITLE
Add GZipMiddleware bypass benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,3 +18,9 @@ Payload construction and decompression validation are outside the measured
 region. Each case creates only one input payload, so the largest case does not
 leave all benchmark inputs resident in memory. CodSpeed CI records simulated
 CPU performance, peak heap usage, and allocation counts.
+
+The end-to-end bypass benchmarks run the complete `GZipMiddleware` ASGI path
+for responses below `minimum_size`, responses with an existing
+`Content-Encoding`, `text/event-stream` responses, and
+`http.response.pathsend`. Their response payloads are also constructed outside
+the measured region, isolating middleware allocation overhead.

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -45,7 +45,10 @@ class StaticResponseApp:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         for message in self.messages:
-            await send(message)
+            outgoing: Message = dict(message)
+            if "headers" in outgoing:
+                outgoing["headers"] = list(outgoing["headers"])
+            await send(outgoing)
 
 
 class ASGIRunner:

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -4,19 +4,21 @@ import gzip
 import hashlib
 import io
 import json
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from starlette.middleware.gzip import GZipResponder
-from starlette.types import Receive, Scope, Send
+from starlette.middleware.gzip import GZipMiddleware, GZipResponder
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 KiB = 1024
 MiB = 1024 * KiB
 
 PayloadKind = Literal["json", "text", "incompressible"]
+BypassReason = Literal["below-minimum-size", "content-encoding", "event-stream", "pathsend"]
 
 
 @dataclass(frozen=True)
@@ -29,6 +31,45 @@ class BenchmarkCase:
     def id(self) -> str:
         size = f"{self.size // MiB}MiB" if self.size >= MiB else f"{self.size // KiB}KiB"
         return f"{self.payload_kind}-{size}-level-{self.level}"
+
+
+@dataclass(frozen=True)
+class BypassCase:
+    reason: BypassReason
+    body_size: int
+
+
+class StaticResponseApp:
+    def __init__(self, messages: tuple[Message, ...]) -> None:
+        self.messages = messages
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        for message in self.messages:
+            await send(message)
+
+
+class ASGIRunner:
+    """Drive an ASGI app that does not suspend on external I/O."""
+
+    def __init__(self) -> None:
+        self.messages: list[Message] = []
+
+    async def receive(self) -> Message:
+        raise AssertionError("The benchmark app must not receive a request body")
+
+    async def send(self, message: Message) -> None:
+        self.messages.append(message)
+
+    def run(self, app: ASGIApp, scope: Scope) -> list[Message]:
+        self.messages.clear()
+        awaitable = app(scope, self.receive, self.send)
+        coroutine = cast(Coroutine[object, object, None], awaitable)
+        try:
+            yielded = coroutine.send(None)
+        except StopIteration:
+            return self.messages
+        coroutine.close()
+        raise AssertionError(f"The benchmark app unexpectedly suspended with {yielded!r}")
 
 
 # All compression levels are compared at 1 MiB. The size curve uses three
@@ -113,6 +154,21 @@ def compress(payload: bytes, level: int) -> bytes:
         return responder.apply_compression(payload, more_body=False)
 
 
+def make_bypass_messages(case: BypassCase) -> tuple[Message, ...]:
+    headers = [(b"content-type", b"application/json"), (b"content-length", str(case.body_size).encode())]
+    if case.reason == "content-encoding":
+        headers.append((b"content-encoding", b"br"))
+    elif case.reason == "event-stream":
+        headers[0] = (b"content-type", b"text/event-stream")
+
+    response_start: Message = {"type": "http.response.start", "status": 200, "headers": headers}
+    if case.reason == "pathsend":
+        response_body: Message = {"type": "http.response.pathsend", "path": "/tmp/starlette-benchmark"}
+    else:
+        response_body = {"type": "http.response.body", "body": b"x" * case.body_size}
+    return response_start, response_body
+
+
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
 @pytest.mark.benchmark(max_time=0.5, max_rounds=10)
 def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
@@ -125,3 +181,29 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     benchmark.extra_info["input_bytes"] = len(payload)
     benchmark.extra_info["output_bytes"] = len(compressed)
     benchmark.extra_info["compression_ratio"] = len(compressed) / len(payload)
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        BypassCase("below-minimum-size", 499),
+        BypassCase("content-encoding", MiB),
+        BypassCase("event-stream", MiB),
+        BypassCase("pathsend", MiB),
+    ),
+    ids=lambda case: case.reason,
+)
+@pytest.mark.benchmark(max_time=0.5, max_rounds=10)
+def test_gzip_bypass(benchmark: BenchmarkFixture, case: BypassCase) -> None:
+    # The response and payload are constructed outside the measured region.
+    # The benchmark covers the complete GZipMiddleware ASGI call, including
+    # responder and compressor initialization for responses that pass through.
+    expected = make_bypass_messages(case)
+    app = GZipMiddleware(StaticResponseApp(expected), minimum_size=500)
+    runner = ASGIRunner()
+
+    sent = benchmark(runner.run, app, {"type": "http", "headers": [(b"accept-encoding", b"gzip")]})
+
+    assert sent == list(expected)
+    benchmark.extra_info["response_bytes"] = case.body_size
+    benchmark.extra_info["bypass_reason"] = case.reason

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -6,7 +6,7 @@ import io
 import json
 from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
@@ -45,10 +45,7 @@ class StaticResponseApp:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         for message in self.messages:
-            outgoing: Message = dict(message)
-            if "headers" in outgoing:
-                outgoing["headers"] = list(outgoing["headers"])
-            await send(outgoing)
+            await send(message)
 
 
 class ASGIRunner:
@@ -172,6 +169,15 @@ def make_bypass_messages(case: BypassCase) -> tuple[Message, ...]:
     return response_start, response_body
 
 
+def setup_bypass(case: BypassCase) -> tuple[tuple[ASGIRunner, ASGIApp, Scope], dict[str, Any]]:
+    messages = make_bypass_messages(case)
+    app = GZipMiddleware(StaticResponseApp(messages), minimum_size=500)
+    scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
+    if case.reason == "pathsend":
+        scope["extensions"] = {"http.response.pathsend": {}}
+    return (ASGIRunner(), app, scope), {}
+
+
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
 @pytest.mark.benchmark(max_time=0.5, max_rounds=10)
 def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
@@ -202,10 +208,7 @@ def test_gzip_bypass(benchmark: BenchmarkFixture, case: BypassCase) -> None:
     # The benchmark covers the complete GZipMiddleware ASGI call, including
     # responder and compressor initialization for responses that pass through.
     expected = make_bypass_messages(case)
-    app = GZipMiddleware(StaticResponseApp(expected), minimum_size=500)
-    runner = ASGIRunner()
-
-    sent = benchmark(runner.run, app, {"type": "http", "headers": [(b"accept-encoding", b"gzip")]})
+    sent = benchmark.pedantic(ASGIRunner.run, setup=lambda: setup_bypass(case), rounds=1)
 
     assert sent == list(expected)
     benchmark.extra_info["response_bytes"] = case.body_size


### PR DESCRIPTION
## Summary

- add end-to-end GZipMiddleware benchmarks for responses below `minimum_size`
- cover responses with an existing `Content-Encoding`
- cover `text/event-stream` and `http.response.pathsend` bypass paths
- record response size and bypass reason as CodSpeed metadata

## Rationale

GZipResponder currently creates its gzip buffer and compressor before it knows whether a response should be compressed. These benchmarks establish CPU and memory baselines for the four main bypass paths before changing that allocation behavior.

Response payload construction happens outside the measured region, and each benchmark verifies that the complete ASGI message sequence passes through unchanged.

## Impact

This only extends the benchmark suite and documentation. Runtime middleware behavior is unchanged.

## Validation

- `scripts/check`
- `pytest benchmarks/gzip_benchmark.py -q` — 67 passed
- `pytest benchmarks/gzip_benchmark.py --codspeed -q -k bypass` — 4 benchmarked
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

