### PR TITLE
Lazily allocate GZipMiddleware compression resources

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -1,5 +1,6 @@
 import gzip
 import io
+from contextlib import ExitStack
 from typing import NoReturn
 
 from starlette.datastructures import Headers, MutableHeaders
@@ -122,14 +123,28 @@ class GZipResponder(IdentityResponder):
     def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:
         super().__init__(app, minimum_size)
 
-        self.gzip_buffer = io.BytesIO()
-        self.gzip_file = gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=compresslevel)
+        self.compresslevel = compresslevel
+        self.gzip_buffer: io.BytesIO | None = None
+        self.gzip_file: gzip.GzipFile | None = None
+        self._gzip_context = ExitStack()
+
+    def _ensure_compression_started(self) -> None:
+        if self.gzip_buffer is None:
+            self.gzip_buffer = self._gzip_context.enter_context(io.BytesIO())
+        if self.gzip_file is None:
+            self.gzip_file = self._gzip_context.enter_context(
+                gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=self.compresslevel)
+            )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        with self.gzip_buffer, self.gzip_file:
+        with self._gzip_context:
             await super().__call__(scope, receive, send)
 
     def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
+        self._ensure_compression_started()
+        assert self.gzip_file is not None
+        assert self.gzip_buffer is not None
+
         self.gzip_file.write(body)
         if not more_body:
             self.gzip_file.close()

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -124,27 +124,29 @@ class GZipResponder(IdentityResponder):
         super().__init__(app, minimum_size)
 
         self.compresslevel = compresslevel
-        self.gzip_buffer: io.BytesIO | None = None
-        self.gzip_file: gzip.GzipFile | None = None
+        self._gzip_buffer: io.BytesIO | None = None
+        self._gzip_file: gzip.GzipFile | None = None
         self._gzip_context = ExitStack()
 
-    def _ensure_compression_started(self) -> None:
-        if self.gzip_buffer is None:
-            self.gzip_buffer = self._gzip_context.enter_context(io.BytesIO())
-        if self.gzip_file is None:
-            self.gzip_file = self._gzip_context.enter_context(
+    @property
+    def gzip_buffer(self) -> io.BytesIO:
+        if self._gzip_buffer is None:
+            self._gzip_buffer = self._gzip_context.enter_context(io.BytesIO())
+        return self._gzip_buffer
+
+    @property
+    def gzip_file(self) -> gzip.GzipFile:
+        if self._gzip_file is None:
+            self._gzip_file = self._gzip_context.enter_context(
                 gzip.GzipFile(mode="wb", fileobj=self.gzip_buffer, compresslevel=self.compresslevel)
             )
+        return self._gzip_file
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         with self._gzip_context:
             await super().__call__(scope, receive, send)
 
     def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:
-        self._ensure_compression_started()
-        assert self.gzip_file is not None
-        assert self.gzip_buffer is not None
-
         self.gzip_file.write(body)
         if not more_body:
             self.gzip_file.close()

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -52,13 +52,7 @@ def test_gzip_not_in_accept_encoding(test_client_factory: TestClientFactory) -> 
 
 def test_gzip_ignored_for_small_responses(
     test_client_factory: TestClientFactory,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fail_if_created(*_args: object, **_kwargs: object) -> None:
-        raise AssertionError("GzipFile should not be created for a response below minimum_size")
-
-    monkeypatch.setattr("starlette.middleware.gzip.gzip.GzipFile", fail_if_created)
-
     def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("OK", status_code=200)
 

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -6,11 +6,11 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware, GZipResponder
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import ContentStream, FileResponse, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
-from starlette.types import Message, Receive, Scope, Send
+from starlette.types import Message
 from tests.types import TestClientFactory
 
 
@@ -200,110 +200,3 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert len(events) == 2
     assert events[0]["type"] == "http.response.start"
     assert events[1]["type"] == "http.response.pathsend"
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("messages", "minimum_size"),
-    [
-        (
-            (
-                {"type": "http.response.start", "status": 200, "headers": []},
-                {"type": "http.response.body", "body": b"small"},
-            ),
-            500,
-        ),
-        (
-            (
-                {
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [(b"content-encoding", b"br")],
-                },
-                {"type": "http.response.body", "body": b"x" * 1000},
-            ),
-            500,
-        ),
-        (
-            (
-                {
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [(b"content-type", b"text/event-stream")],
-                },
-                {"type": "http.response.body", "body": b"x" * 1000},
-            ),
-            500,
-        ),
-        (
-            (
-                {"type": "http.response.start", "status": 200, "headers": []},
-                {"type": "http.response.pathsend", "path": "/tmp/example"},
-            ),
-            500,
-        ),
-    ],
-    ids=["below-minimum-size", "content-encoding", "event-stream", "pathsend"],
-)
-async def test_gzip_responder_does_not_allocate_for_bypassed_responses(
-    messages: tuple[Message, ...], minimum_size: int
-) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        for message in messages:
-            await send(message)
-
-    async def receive() -> Message:  # type: ignore[empty-body]
-        ...  # pragma: no cover
-
-    async def send(message: Message) -> None:
-        pass
-
-    responder = GZipResponder(app, minimum_size=minimum_size)
-    await responder({"type": "http"}, receive, send)
-
-    assert responder._gzip_buffer is None
-    assert responder._gzip_file is None
-
-
-@pytest.mark.anyio
-async def test_gzip_responder_closes_allocated_resources() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"x" * 1000})
-
-    async def receive() -> Message:  # type: ignore[empty-body]
-        ...  # pragma: no cover
-
-    async def send(message: Message) -> None:
-        pass
-
-    responder = GZipResponder(app, minimum_size=500)
-    await responder({"type": "http"}, receive, send)
-
-    assert responder.gzip_buffer is not None
-    assert responder.gzip_buffer.closed
-    assert responder.gzip_file is not None
-    assert responder.gzip_file.closed
-
-
-@pytest.mark.anyio
-async def test_gzip_responder_closes_allocated_resources_on_error() -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"x" * 1000, "more_body": True})
-        raise RuntimeError("application failed")
-
-    async def receive() -> Message:  # type: ignore[empty-body]
-        ...  # pragma: no cover
-
-    async def send(message: Message) -> None:
-        pass
-
-    responder = GZipResponder(app, minimum_size=500)
-    with pytest.raises(RuntimeError, match="application failed"):
-        await responder({"type": "http"}, receive, send)
-
-    assert responder.gzip_buffer is not None
-    assert responder.gzip_buffer.closed
-    assert responder.gzip_file is not None
-    assert responder.gzip_file.closed

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -6,11 +6,11 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import GZipMiddleware, GZipResponder
 from starlette.requests import Request
 from starlette.responses import ContentStream, FileResponse, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
-from starlette.types import Message
+from starlette.types import Message, Receive, Scope, Send
 from tests.types import TestClientFactory
 
 
@@ -200,3 +200,110 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert len(events) == 2
     assert events[0]["type"] == "http.response.start"
     assert events[1]["type"] == "http.response.pathsend"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("messages", "minimum_size"),
+    [
+        (
+            (
+                {"type": "http.response.start", "status": 200, "headers": []},
+                {"type": "http.response.body", "body": b"small"},
+            ),
+            500,
+        ),
+        (
+            (
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-encoding", b"br")],
+                },
+                {"type": "http.response.body", "body": b"x" * 1000},
+            ),
+            500,
+        ),
+        (
+            (
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"text/event-stream")],
+                },
+                {"type": "http.response.body", "body": b"x" * 1000},
+            ),
+            500,
+        ),
+        (
+            (
+                {"type": "http.response.start", "status": 200, "headers": []},
+                {"type": "http.response.pathsend", "path": "/tmp/example"},
+            ),
+            500,
+        ),
+    ],
+    ids=["below-minimum-size", "content-encoding", "event-stream", "pathsend"],
+)
+async def test_gzip_responder_does_not_allocate_for_bypassed_responses(
+    messages: tuple[Message, ...], minimum_size: int
+) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        for message in messages:
+            await send(message)
+
+    async def receive() -> Message:
+        return {"type": "http.request"}
+
+    async def send(message: Message) -> None:
+        pass
+
+    responder = GZipResponder(app, minimum_size=minimum_size)
+    await responder({"type": "http"}, receive, send)
+
+    assert responder.gzip_buffer is None
+    assert responder.gzip_file is None
+
+
+@pytest.mark.anyio
+async def test_gzip_responder_closes_allocated_resources() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"x" * 1000})
+
+    async def receive() -> Message:
+        return {"type": "http.request"}
+
+    async def send(message: Message) -> None:
+        pass
+
+    responder = GZipResponder(app, minimum_size=500)
+    await responder({"type": "http"}, receive, send)
+
+    assert responder.gzip_buffer is not None
+    assert responder.gzip_buffer.closed
+    assert responder.gzip_file is not None
+    assert responder.gzip_file.closed
+
+
+@pytest.mark.anyio
+async def test_gzip_responder_closes_allocated_resources_on_error() -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"x" * 1000, "more_body": True})
+        raise RuntimeError("application failed")
+
+    async def receive() -> Message:
+        return {"type": "http.request"}
+
+    async def send(message: Message) -> None:
+        pass
+
+    responder = GZipResponder(app, minimum_size=500)
+    with pytest.raises(RuntimeError, match="application failed"):
+        await responder({"type": "http"}, receive, send)
+
+    assert responder.gzip_buffer is not None
+    assert responder.gzip_buffer.closed
+    assert responder.gzip_file is not None
+    assert responder.gzip_file.closed

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -261,8 +261,8 @@ async def test_gzip_responder_does_not_allocate_for_bypassed_responses(
     responder = GZipResponder(app, minimum_size=minimum_size)
     await responder({"type": "http"}, receive, send)
 
-    assert responder.gzip_buffer is None
-    assert responder.gzip_file is None
+    assert responder._gzip_buffer is None
+    assert responder._gzip_file is None
 
 
 @pytest.mark.anyio

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -252,8 +252,8 @@ async def test_gzip_responder_does_not_allocate_for_bypassed_responses(
         for message in messages:
             await send(message)
 
-    async def receive() -> Message:
-        return {"type": "http.request"}
+    async def receive() -> Message:  # type: ignore[empty-body]
+        ...  # pragma: no cover
 
     async def send(message: Message) -> None:
         pass
@@ -271,8 +271,8 @@ async def test_gzip_responder_closes_allocated_resources() -> None:
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"x" * 1000})
 
-    async def receive() -> Message:
-        return {"type": "http.request"}
+    async def receive() -> Message:  # type: ignore[empty-body]
+        ...  # pragma: no cover
 
     async def send(message: Message) -> None:
         pass
@@ -293,8 +293,8 @@ async def test_gzip_responder_closes_allocated_resources_on_error() -> None:
         await send({"type": "http.response.body", "body": b"x" * 1000, "more_body": True})
         raise RuntimeError("application failed")
 
-    async def receive() -> Message:
-        return {"type": "http.request"}
+    async def receive() -> Message:  # type: ignore[empty-body]
+        ...  # pragma: no cover
 
     async def send(message: Message) -> None:
         pass

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -52,7 +52,13 @@ def test_gzip_not_in_accept_encoding(test_client_factory: TestClientFactory) -> 
 
 def test_gzip_ignored_for_small_responses(
     test_client_factory: TestClientFactory,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def fail_if_created(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("GzipFile should not be created for a response below minimum_size")
+
+    monkeypatch.setattr("starlette.middleware.gzip.gzip.GzipFile", fail_if_created)
+
     def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("OK", status_code=200)
 


### PR DESCRIPTION
## Summary

- lazily allocate `BytesIO` and `GzipFile` only when a response is compressed
- retain context-managed, reverse-order cleanup on normal completion and application errors
- add regression coverage for responses below `minimum_size`, existing `Content-Encoding`, `text/event-stream`, and `http.response.pathsend`
- update the gzip benchmark to use the lazy compression context

## Motivation

`GZipResponder` previously constructed the gzip buffer and compressor before it knew whether the response should be compressed. Bypassed responses therefore paid the compressor's allocation cost even though their body was forwarded unchanged.

This keeps the public `GZipMiddleware` configuration and response behavior unchanged while avoiding those allocations for bypassed responses. CodSpeed's memory-mode bypass benchmarks will measure the resulting allocation reduction.

## Validation

- `scripts/check`
- `uv run pytest` — 989 passed, 2 skipped, 2 xfailed
- focused gzip tests and representative CodSpeed benchmark cases on Python 3.14

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

