### PR TITLE
Exercise GZipMiddleware benchmarks through ASGI

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,10 +17,12 @@ uv run pytest benchmarks/gzip_benchmark.py --codspeed
 
 Payload construction, middleware configuration, and decompression validation
 are outside the measured region. The measured call includes responder
-construction, header handling, compression, and resource cleanup. Each case
-creates only one input payload, so the largest case does not leave all benchmark
-inputs resident in memory. CodSpeed CI records simulated CPU performance, peak
-heap usage, and allocation counts.
+construction, fresh mutable ASGI message containers, header handling,
+compression, and resource cleanup. Recreating the message containers prevents
+CodSpeed warmups from mutating the response used by the measured invocation.
+Each case creates only one input payload, so the largest case does not leave all
+benchmark inputs resident in memory. CodSpeed CI records simulated CPU
+performance, peak heap usage, and allocation counts.
 
 The end-to-end bypass benchmarks run the complete `GZipMiddleware` ASGI path
 for responses below `minimum_size`, responses with an existing

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,8 @@
 # Benchmarks
 
-The gzip benchmark exercises Starlette's `GZipResponder` with deterministic
-payloads representing valid JSON, repetitive text, and incompressible bytes.
+The gzip benchmark exercises Starlette's `GZipMiddleware` through its ASGI
+interface with deterministic payloads representing valid JSON, repetitive
+text, and incompressible bytes.
 
 It compares levels 1 through 9 at 1 MiB. It also compares representative levels
 1, 6, and 9 at 32 KiB, 256 KiB, 5 MiB, and 10 MiB. This keeps the suite useful
@@ -14,10 +15,12 @@ Run it locally with:
 uv run pytest benchmarks/gzip_benchmark.py --codspeed
 ```
 
-Payload construction and decompression validation are outside the measured
-region. Each case creates only one input payload, so the largest case does not
-leave all benchmark inputs resident in memory. CodSpeed CI records simulated
-CPU performance, peak heap usage, and allocation counts.
+Payload construction, middleware configuration, and decompression validation
+are outside the measured region. The measured call includes responder
+construction, header handling, compression, and resource cleanup. Each case
+creates only one input payload, so the largest case does not leave all benchmark
+inputs resident in memory. CodSpeed CI records simulated CPU performance, peak
+heap usage, and allocation counts.
 
 The end-to-end bypass benchmarks run the complete `GZipMiddleware` ASGI path
 for responses below `minimum_size`, responses with an existing

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -6,12 +6,12 @@ import io
 import json
 from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Literal, cast
 
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
-from starlette.middleware.gzip import GZipMiddleware, GZipResponder
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 KiB = 1024
@@ -86,10 +86,6 @@ CASES = tuple(
 )
 
 
-async def unused_app(scope: Scope, receive: Receive, send: Send) -> None:
-    raise AssertionError("The benchmark calls GZipResponder directly")
-
-
 def make_json_payload(size: int) -> bytes:
     """Build a deterministic, valid JSON document of exactly ``size`` bytes."""
     prefix = b'{"requests":['
@@ -148,12 +144,6 @@ def make_payload(kind: PayloadKind, size: int) -> bytes:
     return hashlib.shake_256(b"starlette-gzip-benchmark-v1").digest(size)
 
 
-def compress(payload: bytes, level: int) -> bytes:
-    responder = GZipResponder(unused_app, minimum_size=0, compresslevel=level)
-    with responder.gzip_buffer, responder.gzip_file:
-        return responder.apply_compression(payload, more_body=False)
-
-
 def make_bypass_messages(case: BypassCase) -> tuple[Message, ...]:
     headers = [(b"content-type", b"application/json"), (b"content-length", str(case.body_size).encode())]
     if case.reason == "content-encoding":
@@ -169,22 +159,29 @@ def make_bypass_messages(case: BypassCase) -> tuple[Message, ...]:
     return response_start, response_body
 
 
-def setup_bypass(case: BypassCase) -> tuple[tuple[ASGIRunner, ASGIApp, Scope], dict[str, Any]]:
-    messages = make_bypass_messages(case)
-    app = GZipMiddleware(StaticResponseApp(messages), minimum_size=500)
-    scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
-    if case.reason == "pathsend":
-        scope["extensions"] = {"http.response.pathsend": {}}
-    return (ASGIRunner(), app, scope), {}
-
-
 @pytest.mark.parametrize("case", CASES, ids=lambda case: case.id)
 @pytest.mark.benchmark(max_time=0.5, max_rounds=10)
 def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     # Payload construction is intentionally outside the measured region. Cases
     # are function-scoped, so only one source payload is resident at a time.
     payload = make_payload(case.payload_kind, case.size)
-    compressed = benchmark(compress, payload, case.level)
+    messages: tuple[Message, ...] = (
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())],
+        },
+        {"type": "http.response.body", "body": payload},
+    )
+    app = GZipMiddleware(StaticResponseApp(messages), minimum_size=0, compresslevel=case.level)
+    scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
+    sent = benchmark.pedantic(ASGIRunner().run, args=(app, scope), rounds=1)
+
+    assert len(sent) == 2
+    assert sent[0]["type"] == "http.response.start"
+    assert (b"content-encoding", b"gzip") in sent[0]["headers"]
+    assert sent[1]["type"] == "http.response.body"
+    compressed = cast(bytes, sent[1]["body"])
 
     assert gzip.decompress(compressed) == payload
     benchmark.extra_info["input_bytes"] = len(payload)
@@ -206,9 +203,13 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
 def test_gzip_bypass(benchmark: BenchmarkFixture, case: BypassCase) -> None:
     # The response and payload are constructed outside the measured region.
     # The benchmark covers the complete GZipMiddleware ASGI call, including
-    # responder and compressor initialization for responses that pass through.
+    # responder construction and teardown for responses passed through uncompressed.
     expected = make_bypass_messages(case)
-    sent = benchmark.pedantic(ASGIRunner.run, setup=lambda: setup_bypass(case), rounds=1)
+    app = GZipMiddleware(StaticResponseApp(expected), minimum_size=500)
+    scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
+    if case.reason == "pathsend":
+        scope["extensions"] = {"http.response.pathsend": {}}
+    sent = benchmark.pedantic(ASGIRunner().run, args=(app, scope), rounds=1)
 
     assert sent == list(expected)
     benchmark.extra_info["response_bytes"] = case.body_size

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -45,7 +45,10 @@ class StaticResponseApp:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         for message in self.messages:
-            await send(message)
+            outgoing_message = dict(message)
+            if "headers" in outgoing_message:
+                outgoing_message["headers"] = list(outgoing_message["headers"])
+            await send(outgoing_message)
 
 
 class ASGIRunner:
@@ -202,9 +205,9 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
 )
 @pytest.mark.benchmark(max_time=0.5, max_rounds=10)
 def test_gzip_bypass(benchmark: BenchmarkFixture, case: BypassCase) -> None:
-    # The response and payload are constructed outside the measured region.
-    # The benchmark covers the complete GZipMiddleware ASGI call, including
-    # responder construction and teardown for responses passed through uncompressed.
+    # The response payload is constructed outside the measured region. The
+    # benchmark covers the complete GZipMiddleware ASGI call, including fresh
+    # ASGI message containers, responder construction, and teardown.
     expected = make_bypass_messages(case)
     app = GZipMiddleware(StaticResponseApp(expected), minimum_size=500)
     scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -181,7 +181,8 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     assert sent[0]["type"] == "http.response.start"
     assert (b"content-encoding", b"gzip") in sent[0]["headers"]
     assert sent[1]["type"] == "http.response.body"
-    compressed = cast(bytes, sent[1]["body"])
+    compressed = sent[1]["body"]
+    assert isinstance(compressed, bytes)
 
     assert gzip.decompress(compressed) == payload
     benchmark.extra_info["input_bytes"] = len(payload)


### PR DESCRIPTION
## Summary

- exercise gzip compression benchmarks through the public `GZipMiddleware` ASGI interface
- include responder construction, header handling, compression, and cleanup in the measured call
- remove direct use of `GZipResponder` and its internal resource lifecycle
- simplify benchmark setup without nested setup-protocol return values

## Motivation

This establishes an end-to-end benchmark baseline before the lazy gzip allocation change in #3407. Keeping the benchmark refactor separate makes the performance comparison in that PR clear and attributable to the middleware change.

## Validation

- `scripts/check`
- `uv run pytest benchmarks/gzip_benchmark.py --codspeed` — 67 passed on Python 3.14

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

