### PR TITLE
Add GZip event-loop responsiveness benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,3 +29,11 @@ for responses below `minimum_size`, responses with an existing
 `Content-Encoding`, `text/event-stream` responses, and
 `http.response.pathsend`. Their response payloads are also constructed outside
 the measured region, isolating middleware allocation overhead.
+
+The responsiveness benchmark schedules a 10 MiB JSON response immediately
+before a tiny response that bypasses compression. CodSpeed measures the work
+needed for the tiny response to complete, then drains and validates the large
+response outside the measured region. This provides a stable CPU-simulation
+benchmark for detecting event-loop starvation without relying on wall-clock
+timing or concurrent request storms. The existing `json-10MiB-level-9`
+compression case separately measures the large response's total completion.

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import gzip
 import hashlib
 import io
 import json
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from typing import Literal, cast
 
+import anyio
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
@@ -73,6 +76,97 @@ class ASGIRunner:
             return self.messages
         coroutine.close()
         raise AssertionError(f"The benchmark app unexpectedly suspended with {yielded!r}")
+
+
+async def run_asgi(app: ASGIApp, scope: Scope) -> list[Message]:
+    messages: list[Message] = []
+
+    async def receive() -> Message:
+        raise AssertionError("The benchmark app must not receive a request body")
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+    return messages
+
+
+@dataclass
+class ResponsePair:
+    runner: asyncio.Runner
+    large_app: ASGIApp
+    tiny_app: ASGIApp
+    scope: Scope
+    payload: bytes
+    large_task: asyncio.Task[list[Message]] | None = None
+    tiny_messages: list[Message] | None = None
+
+    async def warm_worker(self) -> None:
+        await anyio.to_thread.run_sync(bool)
+
+    def run_until_tiny_response(self) -> None:
+        self.runner.run(self._run_until_tiny_response())
+
+    async def _run_until_tiny_response(self) -> None:
+        self.large_task = asyncio.create_task(run_asgi(self.large_app, self.scope))
+        tiny_task = asyncio.create_task(run_asgi(self.tiny_app, self.scope))
+        self.tiny_messages = await tiny_task
+
+    def drain_and_validate(self) -> None:
+        self.runner.run(self._drain_and_validate())
+
+    async def _drain_and_validate(self) -> None:
+        assert self.large_task is not None
+        large_messages = await self.large_task
+        assert self.tiny_messages is not None
+
+        assert len(large_messages) == 2
+        assert large_messages[0]["type"] == "http.response.start"
+        assert (b"content-encoding", b"gzip") in large_messages[0]["headers"]
+        assert large_messages[1]["type"] == "http.response.body"
+        compressed = large_messages[1]["body"]
+        assert isinstance(compressed, bytes)
+        assert gzip.decompress(compressed) == self.payload
+
+        assert len(self.tiny_messages) == 2
+        assert self.tiny_messages[0]["type"] == "http.response.start"
+        assert (b"content-encoding", b"gzip") not in self.tiny_messages[0]["headers"]
+        assert self.tiny_messages[1] == {"type": "http.response.body", "body": b"{}"}
+
+
+@contextmanager
+def response_pair(large_app: ASGIApp, tiny_app: ASGIApp, scope: Scope, payload: bytes) -> Iterator[ResponsePair]:
+    with asyncio.Runner() as runner:
+        pair = ResponsePair(runner, large_app, tiny_app, scope, payload)
+        runner.run(pair.warm_worker())
+        yield pair
+        pair.drain_and_validate()
+
+
+class ResponsivenessBenchmark:
+    def __init__(self, large_app: ASGIApp, tiny_app: ASGIApp, scope: Scope, payload: bytes) -> None:
+        self.large_app = large_app
+        self.tiny_app = tiny_app
+        self.scope = scope
+        self.payload = payload
+        self._stack: ExitStack | None = None
+        self._pair: ResponsePair | None = None
+
+    def setup(self) -> None:
+        stack = ExitStack()
+        pair = stack.enter_context(response_pair(self.large_app, self.tiny_app, self.scope, self.payload))
+        self._stack = stack
+        self._pair = pair
+
+    def run_until_tiny_response(self) -> None:
+        assert self._pair is not None
+        self._pair.run_until_tiny_response()
+
+    def teardown(self) -> None:
+        assert self._stack is not None
+        self._stack.close()
+        self._stack = None
+        self._pair = None
 
 
 # All compression levels are compared at 1 MiB. The size curve uses three
@@ -191,6 +285,42 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     benchmark.extra_info["input_bytes"] = len(payload)
     benchmark.extra_info["output_bytes"] = len(compressed)
     benchmark.extra_info["compression_ratio"] = len(compressed) / len(payload)
+
+
+@pytest.mark.benchmark(max_time=0.5, max_rounds=1)
+def test_gzip_event_loop_responsiveness(benchmark: BenchmarkFixture) -> None:
+    payload = make_json_payload(10 * MiB)
+    large_messages: tuple[Message, ...] = (
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())],
+        },
+        {"type": "http.response.body", "body": payload},
+    )
+    tiny_messages: tuple[Message, ...] = (
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json"), (b"content-length", b"2")],
+        },
+        {"type": "http.response.body", "body": b"{}"},
+    )
+    large_app = GZipMiddleware(StaticResponseApp(large_messages), compresslevel=9)
+    tiny_app = GZipMiddleware(StaticResponseApp(tiny_messages), compresslevel=9)
+    scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
+    responsiveness = ResponsivenessBenchmark(large_app, tiny_app, scope, payload)
+
+    benchmark.pedantic(
+        responsiveness.run_until_tiny_response,
+        setup=responsiveness.setup,
+        teardown=responsiveness.teardown,
+        rounds=1,
+    )
+
+    benchmark.extra_info["large_response_bytes"] = len(payload)
+    benchmark.extra_info["compression_level"] = 9
+    benchmark.extra_info["tiny_response_bytes"] = len(b"{}")
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -6,7 +6,7 @@ import hashlib
 import io
 import json
 from collections.abc import Coroutine, Iterator
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, closing, contextmanager
 from dataclasses import dataclass
 from typing import Literal, cast
 
@@ -93,7 +93,7 @@ async def run_asgi(app: ASGIApp, scope: Scope) -> list[Message]:
 
 @dataclass
 class ResponsePair:
-    runner: asyncio.Runner
+    loop: asyncio.AbstractEventLoop
     large_app: ASGIApp
     tiny_app: ASGIApp
     scope: Scope
@@ -105,7 +105,7 @@ class ResponsePair:
         await anyio.to_thread.run_sync(bool)
 
     def run_until_tiny_response(self) -> None:
-        self.runner.run(self._run_until_tiny_response())
+        self.loop.run_until_complete(self._run_until_tiny_response())
 
     async def _run_until_tiny_response(self) -> None:
         self.large_task = asyncio.create_task(run_asgi(self.large_app, self.scope))
@@ -113,7 +113,7 @@ class ResponsePair:
         self.tiny_messages = await tiny_task
 
     def drain_and_validate(self) -> None:
-        self.runner.run(self._drain_and_validate())
+        self.loop.run_until_complete(self._drain_and_validate())
 
     async def _drain_and_validate(self) -> None:
         assert self.large_task is not None
@@ -136,9 +136,9 @@ class ResponsePair:
 
 @contextmanager
 def response_pair(large_app: ASGIApp, tiny_app: ASGIApp, scope: Scope, payload: bytes) -> Iterator[ResponsePair]:
-    with asyncio.Runner() as runner:
-        pair = ResponsePair(runner, large_app, tiny_app, scope, payload)
-        runner.run(pair.warm_worker())
+    with closing(asyncio.new_event_loop()) as loop:
+        pair = ResponsePair(loop, large_app, tiny_app, scope, payload)
+        loop.run_until_complete(pair.warm_worker())
         yield pair
         pair.drain_and_validate()
 


### PR DESCRIPTION
## Summary

- add a CodSpeed benchmark for GZipMiddleware event-loop responsiveness
- schedule a 10 MiB JSON response immediately before a tiny bypass response
- measure only the work required for the tiny response to complete
- drain and validate the large response during benchmark teardown
- document how the responsiveness and total-completion benchmarks complement each other

## Rationale

Large inline gzip operations can delay unrelated event-loop work. A wall-clock benchmark would be noisy on shared GitHub runners, while CodSpeed walltime runners are unavailable to repositories owned by personal accounts.

This benchmark instead gives CodSpeed simulation a deterministic measurement boundary: FIFO task scheduling starts the large response first, then the tiny response, and the measured target returns when the tiny response completes. Payload construction, event-loop creation, worker startup, draining, and validation remain outside the measured region. The existing `json-10MiB-level-9` benchmark continues to measure total response completion separately.

## Validation

- `uv run pytest benchmarks/gzip_benchmark.py -q`
- responsiveness benchmark under pytest-codspeed walltime, simulation, and memory lifecycles
- `scripts/check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

