### PR TITLE
Run ASGI benchmarks on a real event loop

### DIFF
--- a/benchmarks/gzip_benchmark.py
+++ b/benchmarks/gzip_benchmark.py
@@ -5,10 +5,10 @@ import gzip
 import hashlib
 import io
 import json
-from collections.abc import Coroutine, Iterator
+from collections.abc import Iterator
 from contextlib import ExitStack, closing, contextmanager
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Literal
 
 import anyio
 import pytest
@@ -55,27 +55,14 @@ class StaticResponseApp:
 
 
 class ASGIRunner:
-    """Drive an ASGI app that does not suspend on external I/O."""
-
     def __init__(self) -> None:
-        self.messages: list[Message] = []
-
-    async def receive(self) -> Message:
-        raise AssertionError("The benchmark app must not receive a request body")
-
-    async def send(self, message: Message) -> None:
-        self.messages.append(message)
+        self.loop = asyncio.new_event_loop()
 
     def run(self, app: ASGIApp, scope: Scope) -> list[Message]:
-        self.messages.clear()
-        awaitable = app(scope, self.receive, self.send)
-        coroutine = cast(Coroutine[object, object, None], awaitable)
-        try:
-            yielded = coroutine.send(None)
-        except StopIteration:
-            return self.messages
-        coroutine.close()
-        raise AssertionError(f"The benchmark app unexpectedly suspended with {yielded!r}")
+        return self.loop.run_until_complete(run_asgi(app, scope))
+
+    def close(self) -> None:
+        self.loop.close()
 
 
 async def run_asgi(app: ASGIApp, scope: Scope) -> list[Message]:
@@ -272,7 +259,8 @@ def test_gzip(benchmark: BenchmarkFixture, case: BenchmarkCase) -> None:
     )
     app = GZipMiddleware(StaticResponseApp(messages), minimum_size=0, compresslevel=case.level)
     scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
-    sent = benchmark.pedantic(ASGIRunner().run, args=(app, scope), rounds=1)
+    with closing(ASGIRunner()) as runner:
+        sent = benchmark.pedantic(runner.run, args=(app, scope), rounds=1)
 
     assert len(sent) == 2
     assert sent[0]["type"] == "http.response.start"
@@ -343,7 +331,8 @@ def test_gzip_bypass(benchmark: BenchmarkFixture, case: BypassCase) -> None:
     scope: Scope = {"type": "http", "headers": [(b"accept-encoding", b"gzip")]}
     if case.reason == "pathsend":
         scope["extensions"] = {"http.response.pathsend": {}}
-    sent = benchmark.pedantic(ASGIRunner().run, args=(app, scope), rounds=1)
+    with closing(ASGIRunner()) as runner:
+        sent = benchmark.pedantic(runner.run, args=(app, scope), rounds=1)
 
     assert sent == list(expected)
     benchmark.extra_info["response_bytes"] = case.body_size


### PR DESCRIPTION
## Summary

Replace the synchronous coroutine-stepping `ASGIRunner` in the GZip benchmarks with one that drives the app on a real `asyncio` event loop.

## Rationale

The current runner steps the ASGI coroutine manually and asserts it never suspends. That makes it impossible to benchmark middleware that legitimately awaits — such as the worker-thread GZip offload proposed in #3410.

Landing this runner change separately keeps CodSpeed baselines comparable: the event loop adds a small fixed overhead (~0.2 ms) to every benchmark, and if it shipped together with a middleware change, that harness overhead would be misattributed to the middleware (it currently shows up in #3410 as a spurious ~50% regression on the bypass benchmarks, which that PR does not touch).

Once this merges, #3410 rebases to a pure middleware diff and its CodSpeed report reflects only real behavior changes.

## Validation

- `benchmarks/gzip_benchmark.py --codspeed`: 68 passed
- `scripts/check` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

