### PR TITLE
Default `thread_minimum_size` in `GZipResponder`

### DIFF
--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -153,7 +153,7 @@ class GZipResponder(IdentityResponder):
         minimum_size: int,
         compresslevel: int = 9,
         *,
-        thread_minimum_size: int,
+        thread_minimum_size: int = 128 * 1024,  # 128 KiB
     ) -> None:
         super().__init__(app, minimum_size)
 


### PR DESCRIPTION
Give `thread_minimum_size` a default value of 128 KiB in `GZipResponder`, matching the default used by `GZipMiddleware` (introduced in #3410). This keeps `GZipResponder` usable directly without passing the keyword argument, avoiding a breaking change for anyone instantiating it themselves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

