### PR TITLE
Add `exclude_content_types` parameter to `GZipMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -242,9 +242,11 @@ The following arguments are supported:
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
 * `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 * `thread_minimum_size` - Compress body chunks at least this large in a worker thread, keeping the event loop responsive. Defaults to `131072` (128 KiB). Chunks below this size compress inline in at most a couple of milliseconds, while the fixed cost of dispatching to a worker thread would dominate.
+* `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
-The middleware won't GZip responses that already have either a `Content-Encoding` set, to prevent them from
-being encoded twice, or a `Content-Type` set to `text/event-stream`, to avoid compressing server-sent events.
+The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
+encoded twice, or a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to avoid
+compressing server-sent events.
 
 ## BaseHTTPMiddleware
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -9,6 +9,7 @@ import anyio.to_thread
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+# TODO(v2): We should rename `DEFAULT_EXCLUDED_CONTENT_TYPES` to `DEFAULT_EXCLUDE_CONTENT_TYPES`.
 DEFAULT_EXCLUDED_CONTENT_TYPES = ("text/event-stream",)
 
 _gzip_capacity_limiter: anyio.lowlevel.RunVar[anyio.CapacityLimiter] = anyio.lowlevel.RunVar("_gzip_capacity_limiter")

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import zlib
 from typing import NoReturn
 
-import anyio
+import anyio.lowlevel
+import anyio.to_thread
 
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -32,11 +33,14 @@ class GZipMiddleware:
         minimum_size: int = 500,
         compresslevel: int = 9,
         thread_minimum_size: int = 128 * 1024,  # 128 KiB
+        *,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
         self.app = app
         self.minimum_size = minimum_size
         self.compresslevel = compresslevel
         self.thread_minimum_size = thread_minimum_size
+        self.exclude_content_types = _normalize_content_types(exclude_content_types)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":  # pragma: no cover
@@ -51,9 +55,10 @@ class GZipMiddleware:
                 self.minimum_size,
                 compresslevel=self.compresslevel,
                 thread_minimum_size=self.thread_minimum_size,
+                exclude_content_types=self.exclude_content_types,
             )
         else:
-            responder = IdentityResponder(self.app, self.minimum_size)
+            responder = IdentityResponder(self.app, self.minimum_size, exclude_content_types=self.exclude_content_types)
 
         await responder(scope, receive, send)
 
@@ -61,9 +66,16 @@ class GZipMiddleware:
 class IdentityResponder:
     content_encoding: str
 
-    def __init__(self, app: ASGIApp, minimum_size: int) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        minimum_size: int,
+        *,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
+    ) -> None:
         self.app = app
         self.minimum_size = minimum_size
+        self.exclude_content_types = _normalize_content_types(exclude_content_types)
         self.send: Send = unattached_send
         self.initial_message: Message = {}
         self.started = False
@@ -82,7 +94,9 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
-            self.content_type_is_excluded = headers.get("content-type", "").startswith(DEFAULT_EXCLUDED_CONTENT_TYPES)
+            media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
+            media_types = {media_type, media_type.partition("/")[0] + "/*"}
+            self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)
         elif message_type == "http.response.body" and (self.content_encoding_set or self.content_type_is_excluded):
             if not self.started:
                 self.started = True
@@ -154,8 +168,9 @@ class GZipResponder(IdentityResponder):
         compresslevel: int = 9,
         *,
         thread_minimum_size: int = 128 * 1024,  # 128 KiB
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
-        super().__init__(app, minimum_size)
+        super().__init__(app, minimum_size, exclude_content_types=exclude_content_types)
 
         self.compresslevel = compresslevel
         self.thread_minimum_size = thread_minimum_size
@@ -182,3 +197,7 @@ class GZipResponder(IdentityResponder):
 
 async def unattached_send(message: Message) -> NoReturn:
     raise RuntimeError("send awaitable not set")  # pragma: no cover
+
+
+def _normalize_content_types(content_types: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(content_type.partition(";")[0].strip().lower() for content_type in content_types)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -7,7 +7,7 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import GZipMiddleware, GZipResponder
 from starlette.requests import Request
 from starlette.responses import ContentStream, FileResponse, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
@@ -239,3 +239,87 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert len(events) == 2
     assert events[0]["type"] == "http.response.start"
     assert events[1]["type"] == "http.response.pathsend"
+
+
+def test_gzip_custom_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_gzip_cleared_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/event-stream")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=())
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+def test_gzip_exclude_content_types_for_identity_client(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+@pytest.mark.parametrize(
+    ("exclude_content_types", "content_type"),
+    [
+        pytest.param(("text/event-stream",), b"Text/Event-Stream; charset=utf-8", id="header-is-normalized"),
+        pytest.param(("Application/ZIP; charset=utf-8",), b"application/zip", id="configured-value-is-normalized"),
+        pytest.param(("image/*",), b"image/png", id="wildcard"),
+    ],
+)
+def test_gzip_exclude_content_types_matching(
+    exclude_content_types: tuple[str, ...], content_type: bytes, test_client_factory: TestClientFactory
+) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", content_type)]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=exclude_content_types)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_gzip_responder_normalizes_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    responder = GZipResponder(app, 500, exclude_content_types=("Application/ZIP; charset=utf-8",))
+
+    client = test_client_factory(responder)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers


### PR DESCRIPTION
Add a keyword-only `exclude_content_types` parameter to `GZipMiddleware`, replacing the hardcoded exclusion check.

- A response is excluded when its `Content-Type` media type equals an entry, or matches a `type/*` wildcard entry (e.g. `"image/*"`). Matching is case-insensitive and ignores parameters like `charset`; configured values are normalized the same way.
- Defaults to `DEFAULT_EXCLUDED_CONTENT_TYPES` (`("text/event-stream",)`), which stays importable so the defaults can be extended rather than replaced.
- Both responders accept the parameter keyword-only with a default, so direct instantiation keeps working (same pattern as #3415).

Supersedes #3091 and #3040, and implements the feature requested in #3414.

Wire-visible deltas from the previous prefix check, for the release notes: matching is now case-insensitive, `text/event-stream-foo` no longer matches, and reassigning `DEFAULT_EXCLUDED_CONTENT_TYPES` at runtime no longer takes effect (the exclusions are read at construction).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

