### PR TITLE
Flush GZip output for each streamed chunk

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -214,13 +214,12 @@ Handles GZip responses for any request that includes `"gzip"` in the `Accept-Enc
 
 The middleware will handle both standard and streaming responses.
 
-??? info "Buffer on streaming responses"
-    On streaming responses, the middleware will buffer the response before compressing it.
+??? info "Compression of streaming responses"
+    On streaming responses, the middleware compresses and emits output for every chunk the application sends,
+    so chunks reach the client as they are produced instead of waiting for the compressor's buffer to fill.
 
-    The idea is that we don't want to compress every small chunk of data, as it would be inefficient.
-    Instead, we buffer the response until it reaches a certain size, and then compress it.
-
-    This may cause a delay in the response, as the middleware waits for the buffer to fill up before compressing it.
+    This favors timely delivery over compression ratio: many small chunks compress less effectively than a few
+    large ones. Batch the chunks you yield if you want to maximize compression.
 
 ```python
 from starlette.applications import Starlette

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -242,9 +242,11 @@ The following arguments are supported:
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
 * `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 * `thread_minimum_size` - Compress body chunks at least this large in a worker thread, keeping the event loop responsive. Defaults to `131072` (128 KiB). Chunks below this size compress inline in at most a couple of milliseconds, while the fixed cost of dispatching to a worker thread would dominate.
+* `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
-The middleware won't GZip responses that already have either a `Content-Encoding` set, to prevent them from
-being encoded twice, or a `Content-Type` set to `text/event-stream`, to avoid compressing server-sent events.
+The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
+encoded twice, or a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to avoid
+compressing server-sent events.
 
 ## BaseHTTPMiddleware
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -191,7 +191,9 @@ class GZipResponder(IdentityResponder):
 
     def _compress_body(self, body: bytes, more_body: bool) -> bytes:
         if more_body:
-            return self.compressor.compress(body)
+            # Emit everything compressed so far: streamed chunks must reach the
+            # client as the application sends them, not when the buffer fills.
+            return self.compressor.compress(body) + self.compressor.flush(zlib.Z_SYNC_FLUSH)
         return self.compressor.compress(body) + self.compressor.flush()
 
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -9,6 +9,7 @@ import anyio.to_thread
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+# TODO(v2): We should rename `DEFAULT_EXCLUDED_CONTENT_TYPES` to `DEFAULT_EXCLUDE_CONTENT_TYPES`.
 DEFAULT_EXCLUDED_CONTENT_TYPES = ("text/event-stream",)
 
 _gzip_capacity_limiter: anyio.lowlevel.RunVar[anyio.CapacityLimiter] = anyio.lowlevel.RunVar("_gzip_capacity_limiter")

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -192,8 +192,6 @@ class GZipResponder(IdentityResponder):
 
     def _compress_body(self, body: bytes, more_body: bool) -> bytes:
         if more_body:
-            # Emit everything compressed so far: streamed chunks must reach the
-            # client as the application sends them, not when the buffer fills.
             return self.compressor.compress(body) + self.compressor.flush(zlib.Z_SYNC_FLUSH)
         return self.compressor.compress(body) + self.compressor.flush()
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import zlib
 from typing import NoReturn
 
-import anyio
+import anyio.lowlevel
+import anyio.to_thread
 
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -32,11 +33,14 @@ class GZipMiddleware:
         minimum_size: int = 500,
         compresslevel: int = 9,
         thread_minimum_size: int = 128 * 1024,  # 128 KiB
+        *,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
         self.app = app
         self.minimum_size = minimum_size
         self.compresslevel = compresslevel
         self.thread_minimum_size = thread_minimum_size
+        self.exclude_content_types = _normalize_content_types(exclude_content_types)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":  # pragma: no cover
@@ -51,9 +55,10 @@ class GZipMiddleware:
                 self.minimum_size,
                 compresslevel=self.compresslevel,
                 thread_minimum_size=self.thread_minimum_size,
+                exclude_content_types=self.exclude_content_types,
             )
         else:
-            responder = IdentityResponder(self.app, self.minimum_size)
+            responder = IdentityResponder(self.app, self.minimum_size, exclude_content_types=self.exclude_content_types)
 
         await responder(scope, receive, send)
 
@@ -61,9 +66,16 @@ class GZipMiddleware:
 class IdentityResponder:
     content_encoding: str
 
-    def __init__(self, app: ASGIApp, minimum_size: int) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        minimum_size: int,
+        *,
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
+    ) -> None:
         self.app = app
         self.minimum_size = minimum_size
+        self.exclude_content_types = _normalize_content_types(exclude_content_types)
         self.send: Send = unattached_send
         self.initial_message: Message = {}
         self.started = False
@@ -82,7 +94,9 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
-            self.content_type_is_excluded = headers.get("content-type", "").startswith(DEFAULT_EXCLUDED_CONTENT_TYPES)
+            media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
+            media_types = {media_type, media_type.partition("/")[0] + "/*"}
+            self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)
         elif message_type == "http.response.body" and (self.content_encoding_set or self.content_type_is_excluded):
             if not self.started:
                 self.started = True
@@ -154,8 +168,9 @@ class GZipResponder(IdentityResponder):
         compresslevel: int = 9,
         *,
         thread_minimum_size: int = 128 * 1024,  # 128 KiB
+        exclude_content_types: tuple[str, ...] = DEFAULT_EXCLUDED_CONTENT_TYPES,
     ) -> None:
-        super().__init__(app, minimum_size)
+        super().__init__(app, minimum_size, exclude_content_types=exclude_content_types)
 
         self.compresslevel = compresslevel
         self.thread_minimum_size = thread_minimum_size
@@ -182,3 +197,7 @@ class GZipResponder(IdentityResponder):
 
 async def unattached_send(message: Message) -> NoReturn:
     raise RuntimeError("send awaitable not set")  # pragma: no cover
+
+
+def _normalize_content_types(content_types: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(content_type.partition(";")[0].strip().lower() for content_type in content_types)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import zlib
 from pathlib import Path
 
 import pytest
@@ -124,12 +125,25 @@ def test_gzip_streaming_compression_in_thread(test_client_factory: TestClientFac
 
     # Ensure the streamed chunk takes the worker-thread compression path.
     middleware = GZipMiddleware(app, thread_minimum_size=len(chunk))
+    events: list[Message] = []
 
-    client = test_client_factory(middleware)
+    async def recording_app(scope: Scope, receive: Receive, send: Send) -> None:
+        async def record(message: Message) -> None:
+            events.append(message)
+            await send(message)
+
+        await middleware(scope, receive, record)
+
+    client = test_client_factory(recording_app)
     response = client.get("/", headers={"accept-encoding": "gzip"})
     assert response.status_code == 200
     assert response.content == chunk + b"tail"
     assert response.headers["Content-Encoding"] == "gzip"
+
+    assert len(events) == 3
+    decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    assert decompressor.decompress(events[1]["body"]) == chunk
+    assert decompressor.decompress(events[2]["body"]) == b"tail"
 
 
 def test_gzip_streaming_response_identity(test_client_factory: TestClientFactory) -> None:
@@ -239,6 +253,39 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert len(events) == 2
     assert events[0]["type"] == "http.response.start"
     assert events[1]["type"] == "http.response.pathsend"
+
+
+def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
+        await send({"type": "http.response.body", "body": b"data: first\n\n", "more_body": True})
+        await send({"type": "http.response.body", "body": b"", "more_body": True})
+        await send({"type": "http.response.body", "body": b"data: last\n\n"})
+
+    middleware = GZipMiddleware(app)
+    events: list[Message] = []
+
+    async def recording_app(scope: Scope, receive: Receive, send: Send) -> None:
+        async def record(message: Message) -> None:
+            events.append(message)
+            await send(message)
+
+        await middleware(scope, receive, record)
+
+    client = test_client_factory(recording_app)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.text == "data: first\n\ndata: last\n\n"
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+    assert "Content-Length" not in response.headers
+
+    assert len(events) == 4
+    decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    assert decompressor.decompress(events[1]["body"]) == b"data: first\n\n"
+    assert decompressor.decompress(events[2]["body"]) == b""
+    assert decompressor.decompress(events[3]["body"]) == b"data: last\n\n"
+    assert decompressor.eof
 
 
 def test_gzip_custom_exclude_content_types(test_client_factory: TestClientFactory) -> None:

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -7,7 +7,7 @@ import pytest
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.gzip import GZipMiddleware, GZipResponder
 from starlette.requests import Request
 from starlette.responses import ContentStream, FileResponse, PlainTextResponse, StreamingResponse
 from starlette.routing import Route
@@ -239,3 +239,87 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert len(events) == 2
     assert events[0]["type"] == "http.response.start"
     assert events[1]["type"] == "http.response.pathsend"
+
+
+def test_gzip_custom_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_gzip_cleared_exclude_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/event-stream")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=())
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+def test_gzip_exclude_content_types_for_identity_client(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=("application/zip",))
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "identity"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+@pytest.mark.parametrize(
+    ("exclude_content_types", "content_type"),
+    [
+        pytest.param(("text/event-stream",), b"Text/Event-Stream; charset=utf-8", id="header-is-normalized"),
+        pytest.param(("Application/ZIP; charset=utf-8",), b"application/zip", id="configured-value-is-normalized"),
+        pytest.param(("image/*",), b"image/png", id="wildcard"),
+    ],
+)
+def test_gzip_exclude_content_types_matching(
+    exclude_content_types: tuple[str, ...], content_type: bytes, test_client_factory: TestClientFactory
+) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", content_type)]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app, exclude_content_types=exclude_content_types)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_gzip_responder_normalizes_content_types(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    responder = GZipResponder(app, 500, exclude_content_types=("Application/ZIP; charset=utf-8",))
+
+    client = test_client_factory(responder)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers


### PR DESCRIPTION
Compress and emit output for every streamed chunk (`Z_SYNC_FLUSH`), instead of letting zlib buffer across chunks. Chunk boundaries are the application's intent - a compressor should not erase them.

This deliberately reverses the conclusion of #2753 and supersedes #3230 (see also discussion #3231). The precedent moved since #2753 was closed: Django now flushes every streamed chunk unconditionally (`12bb16da8f`, "Fixed #36293 -- Avoided buffering streaming responses in GZipMiddleware"), and Tomcat, Undertow, every Netty-based stack, Apache `mod_deflate`, h2o, Deno's runtime, and salvo all do the same, with no configuration knob.

- Non-streaming responses are unaffected (single-shot bodies were already finalized immediately).
- `text/event-stream` remains excluded by default. With this change, compressed *and* timely SSE is one setting away: `exclude_content_types=()`.
- The worker-thread path (#3410) is unchanged - the flush happens inside `_compress_body` on either path.
- Cost: compression ratio drops for streams that emit many small chunks (~5 bytes overhead per flush plus reduced entropy pooling). Applications wanting maximum ratio can batch their chunks.

Stacked on #3418.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

