### PR TITLE
Skip compression of partial responses in `GZipMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -244,7 +244,7 @@ The following arguments are supported:
 * `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
-encoded twice, partial content responses (status `206` or a `Content-Range` header), to keep range semantics
+encoded twice, partial content responses (status `206`), to keep range semantics
 intact, or responses with a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to
 avoid compressing server-sent events.
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -244,8 +244,9 @@ The following arguments are supported:
 * `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
-encoded twice, or a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to avoid
-compressing server-sent events.
+encoded twice, partial content responses (status `206` or a `Content-Range` header), to keep range semantics
+intact, or responses with a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to
+avoid compressing server-sent events.
 
 ## BaseHTTPMiddleware
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -96,7 +96,7 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
-            self.partial_response = message["status"] == 206 or "content-range" in headers
+            self.partial_response = message["status"] == 206
             media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
             media_types = {media_type, media_type.partition("/")[0] + "/*"}
             self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -82,6 +82,7 @@ class IdentityResponder:
         self.started = False
         self.content_encoding_set = False
         self.content_type_is_excluded = False
+        self.partial_response = False
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send
@@ -95,10 +96,13 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
+            self.partial_response = message["status"] == 206 or "content-range" in headers
             media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
             media_types = {media_type, media_type.partition("/")[0] + "/*"}
             self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)
-        elif message_type == "http.response.body" and (self.content_encoding_set or self.content_type_is_excluded):
+        elif message_type == "http.response.body" and (
+            self.content_encoding_set or self.partial_response or self.content_type_is_excluded
+        ):
             if not self.started:
                 self.started = True
                 await self.send(self.initial_message)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -255,6 +255,47 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert events[1]["type"] == "http.response.pathsend"
 
 
+def test_gzip_ignored_on_range_responses(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    path = tmp_path / "example.txt"
+    path.write_text("x" * 4000)
+
+    def homepage(request: Request) -> FileResponse:
+        return FileResponse(path)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"accept-encoding": "gzip", "range": "bytes=0-1999"})
+    assert response.status_code == 206
+    assert response.content == b"x" * 2000
+    assert "Content-Encoding" not in response.headers
+    assert int(response.headers["Content-Length"]) == 2000
+
+
+def test_gzip_ignored_when_content_range_set(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain"), (b"content-range", b"bytes 0-3999/8000")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
 def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -275,27 +275,6 @@ def test_gzip_ignored_on_range_responses(tmp_path: Path, test_client_factory: Te
     assert int(response.headers["Content-Length"]) == 2000
 
 
-def test_gzip_ignored_when_content_range_set(test_client_factory: TestClientFactory) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": [(b"content-type", b"text/plain"), (b"content-range", b"bytes 0-3999/8000")],
-            }
-        )
-        await send({"type": "http.response.body", "body": b"x" * 4000})
-
-    middleware = GZipMiddleware(app)
-
-    client = test_client_factory(middleware)
-    response = client.get("/", headers={"accept-encoding": "gzip"})
-    assert response.status_code == 200
-    assert response.content == b"x" * 4000
-    assert "Content-Encoding" not in response.headers
-    assert "Vary" not in response.headers
-
-
 def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})


### PR DESCRIPTION
Bypass compression when a response is partial content (status `206`). Compressing a byte range corrupts the `Content-Range`/`Content-Length` semantics (the range refers to the identity representation) and breaks media playback and resumable downloads in browsers; it's the root cause of the range-request breakage that pushed Streamlit to subclass the middleware (see #3414 discussion).

- `FileResponse` range responses now pass through untouched.
- Status-only detection also covers `multipart/byteranges` responses, which carry `Content-Range` inside each body part rather than in the top-level headers.
- No `Vary: Accept-Encoding` on the bypass path - the partial response never varies by encoding, consistent with the existing excluded/pre-encoded handling.
- Precedent: actix-web and Caddy skip status 206 in their encoders; nginx only ever compresses 200/403/404. RFC 9110 defines ranges over the selected representation.

Stacked on #3419.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.