### PR TITLE
Expand default excluded content types in `GZipMiddleware`

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -244,7 +244,7 @@ The following arguments are supported:
 * `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
-encoded twice, partial content responses (status `206` or a `Content-Range` header), to keep range semantics
+encoded twice, partial content responses (status `206`), to keep range semantics
 intact, or responses with a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to
 avoid compressing server-sent events.
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -244,8 +244,9 @@ The following arguments are supported:
 * `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
-encoded twice, or a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to avoid
-compressing server-sent events.
+encoded twice, partial content responses (status `206` or a `Content-Range` header), to keep range semantics
+intact, or responses with a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to
+avoid compressing server-sent events.
 
 ## BaseHTTPMiddleware
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -241,12 +241,13 @@ The following arguments are supported:
 * `minimum_size` - Do not GZip responses that are smaller than this minimum size in bytes. Defaults to `500`.
 * `compresslevel` - Used during GZip compression. It is an integer ranging from 1 to 9. Defaults to `9`. Lower value results in faster compression but larger file sizes, while higher value results in slower compression but smaller file sizes.
 * `thread_minimum_size` - Compress body chunks at least this large in a worker thread, keeping the event loop responsive. Defaults to `131072` (128 KiB). Chunks below this size compress inline in at most a couple of milliseconds, while the fixed cost of dispatching to a worker thread would dominate.
-* `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `("text/event-stream",)`, importable as `DEFAULT_EXCLUDED_CONTENT_TYPES` to extend rather than replace.
+* `exclude_content_types` - Content types that are never compressed. A response is excluded when its `Content-Type` media type equals one of these values, or matches a `type/*` entry like `"image/*"` - matching is case-insensitive and ignores parameters like `charset`. Defaults to `DEFAULT_EXCLUDED_CONTENT_TYPES` (importable, to extend rather than replace): `text/event-stream` plus already-compressed formats - zip and gzip archives, common raster image types, `video/*`, `audio/*`, and WOFF fonts. `image/svg+xml` is deliberately not excluded, since SVG is text and compresses well.
 
 The middleware won't GZip responses that already have a `Content-Encoding` set, to prevent them from being
 encoded twice, partial content responses (status `206` or a `Content-Range` header), to keep range semantics
 intact, or responses with a `Content-Type` in `exclude_content_types` - by default `text/event-stream`, to
-avoid compressing server-sent events.
+avoid compressing server-sent events, and already-compressed formats, where compression wastes CPU for no
+gain.
 
 ## BaseHTTPMiddleware
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -96,7 +96,7 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
-            self.partial_response = message["status"] == 206 or "content-range" in headers
+            self.partial_response = message["status"] == 206
             media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
             media_types = {media_type, media_type.partition("/")[0] + "/*"}
             self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -9,7 +9,21 @@ import anyio.to_thread
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-DEFAULT_EXCLUDED_CONTENT_TYPES = ("text/event-stream",)
+DEFAULT_EXCLUDED_CONTENT_TYPES = (
+    "application/gzip",
+    "application/x-gzip",
+    "application/zip",
+    "audio/*",
+    "font/woff",
+    "font/woff2",
+    "image/avif",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "text/event-stream",
+    "video/*",
+)
 
 _gzip_capacity_limiter: anyio.lowlevel.RunVar[anyio.CapacityLimiter] = anyio.lowlevel.RunVar("_gzip_capacity_limiter")
 

--- a/starlette/middleware/gzip.py
+++ b/starlette/middleware/gzip.py
@@ -81,6 +81,7 @@ class IdentityResponder:
         self.started = False
         self.content_encoding_set = False
         self.content_type_is_excluded = False
+        self.partial_response = False
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.send = send
@@ -94,10 +95,13 @@ class IdentityResponder:
             self.initial_message = message
             headers = Headers(raw=self.initial_message["headers"])
             self.content_encoding_set = "content-encoding" in headers
+            self.partial_response = message["status"] == 206 or "content-range" in headers
             media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
             media_types = {media_type, media_type.partition("/")[0] + "/*"}
             self.content_type_is_excluded = not media_types.isdisjoint(self.exclude_content_types)
-        elif message_type == "http.response.body" and (self.content_encoding_set or self.content_type_is_excluded):
+        elif message_type == "http.response.body" and (
+            self.content_encoding_set or self.partial_response or self.content_type_is_excluded
+        ):
             if not self.started:
                 self.started = True
                 await self.send(self.initial_message)

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -255,6 +255,47 @@ async def test_gzip_ignored_for_pathsend_responses(tmpdir: Path) -> None:
     assert events[1]["type"] == "http.response.pathsend"
 
 
+def test_gzip_ignored_on_range_responses(tmp_path: Path, test_client_factory: TestClientFactory) -> None:
+    path = tmp_path / "example.txt"
+    path.write_text("x" * 4000)
+
+    def homepage(request: Request) -> FileResponse:
+        return FileResponse(path)
+
+    app = Starlette(
+        routes=[Route("/", endpoint=homepage)],
+        middleware=[Middleware(GZipMiddleware)],
+    )
+
+    client = test_client_factory(app)
+    response = client.get("/", headers={"accept-encoding": "gzip", "range": "bytes=0-1999"})
+    assert response.status_code == 206
+    assert response.content == b"x" * 2000
+    assert "Content-Encoding" not in response.headers
+    assert int(response.headers["Content-Length"]) == 2000
+
+
+def test_gzip_ignored_when_content_range_set(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain"), (b"content-range", b"bytes 0-3999/8000")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
 def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -275,27 +275,6 @@ def test_gzip_ignored_on_range_responses(tmp_path: Path, test_client_factory: Te
     assert int(response.headers["Content-Length"]) == 2000
 
 
-def test_gzip_ignored_when_content_range_set(test_client_factory: TestClientFactory) -> None:
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": [(b"content-type", b"text/plain"), (b"content-range", b"bytes 0-3999/8000")],
-            }
-        )
-        await send({"type": "http.response.body", "body": b"x" * 4000})
-
-    middleware = GZipMiddleware(app)
-
-    client = test_client_factory(middleware)
-    response = client.get("/", headers={"accept-encoding": "gzip"})
-    assert response.status_code == 200
-    assert response.content == b"x" * 4000
-    assert "Content-Encoding" not in response.headers
-    assert "Vary" not in response.headers
-
-
 def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})

--- a/tests/middleware/test_gzip.py
+++ b/tests/middleware/test_gzip.py
@@ -329,6 +329,40 @@ def test_gzip_streaming_response_emits_output_per_chunk(test_client_factory: Tes
     assert decompressor.eof
 
 
+@pytest.mark.parametrize(
+    "content_type",
+    [b"application/zip", b"audio/mpeg", b"font/woff2", b"image/png", b"video/mp4"],
+)
+def test_gzip_default_exclude_content_types(content_type: bytes, test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", content_type)]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert "Content-Encoding" not in response.headers
+    assert "Vary" not in response.headers
+
+
+def test_gzip_compresses_svg_by_default(test_client_factory: TestClientFactory) -> None:
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"image/svg+xml")]})
+        await send({"type": "http.response.body", "body": b"x" * 4000})
+
+    middleware = GZipMiddleware(app)
+
+    client = test_client_factory(middleware)
+    response = client.get("/", headers={"accept-encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.content == b"x" * 4000
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
 def test_gzip_custom_exclude_content_types(test_client_factory: TestClientFactory) -> None:
     async def app(scope: Scope, receive: Receive, send: Send) -> None:
         await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/zip")]})


### PR DESCRIPTION
Extend `DEFAULT_EXCLUDED_CONTENT_TYPES` beyond `text/event-stream` to cover already-compressed formats, so the middleware stops wasting CPU re-compressing them out of the box: zip/gzip archives, common raster image types (`image/png`, `image/jpeg`, `image/webp`, `image/gif`, `image/avif`), `video/*`, `audio/*`, and WOFF fonts.

Implements the defaults expansion requested in #3040 and #3091 (and Streamlit's subclass workaround). Two deliberate omissions, both grounded in what these formats actually are:

- No `image/*`: `image/svg+xml` is text and gzips to roughly half size (tower-http carves out the same exception). Raster types are enumerated instead.
- No `font/*`: only WOFF/WOFF2 carry internal compression - `font/ttf`/`font/otf` are uncompressed table formats that gzip well.

Behavior change: responses with these content types are no longer compressed by default. Restore the old behavior per type with e.g. `exclude_content_types=("text/event-stream",)`.

Stacked on #3420.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

