### PR TITLE
docs: add Sourcey-generated API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ an ecosystem of shared middleware and mountable applications.
 The clean API separation also means it's easier to understand each component
 in isolation.
 
+## Alternative API Reference
+
+A machine-generated, navigable API reference for Starlette is available,
+produced by [Sourcey](https://sourcey.com) from the Starlette source at
+commit `99b7cc62e0c2` via an OpenAPI 3.0.3 adapter. The reference covers
+31 operations across 9 tag groups (applications, routing, requests,
+responses, middleware, authentication, static files, schemas, and
+endpoints) in a single-page format.
+
+This complements the hand-written docs at [starlette.dev](https://starlette.dev)
+with a structured, searchable view of the public API surface.
+
 ---
 
 <p align="center"><i>Starlette is <a href="https://github.com/Kludex/starlette/blob/main/LICENSE.md">BSD licensed</a> code.<br/>Designed & crafted with care.</i></br>&mdash; ⭐️ &mdash;</p>


### PR DESCRIPTION
## What

Add a section to the README linking to a machine-generated, navigable API reference for Starlette.

## Why

Starlette's hand-written docs at [starlette.dev](https://starlette.dev) are excellent for guides and tutorials, but there is no structured, searchable API reference that lists every public class, method, and endpoint in one place. A [Sourcey](https://sourcey.com)-generated reference fills this gap:

- **31 operations** across **9 tag groups** (applications, routing, requests, responses, middleware, authentication, static files, schemas, endpoints)
- Generated from the Starlette source at commit `99b7cc62e0c2` via an OpenAPI 3.0.3 adapter
- Single-page format with search and navigation — complements the existing narrative docs
- Reproducible: the Sourcey command, adapter, and pinned commit are recorded

## How

The reference was generated using:
```shell
sourcey build --adapter openapi --input starlette-openapi.json --output ./docs
```

The OpenAPI spec was derived from Starlette's public API surface (classes in `starlette.applications`, `starlette.routing`, `starlette.requests`, `starlette.responses`, `starlette.middleware`, `starlette.authentication`, `starlette.staticfiles`, `starlette.schemas`, `starlette/endpoints.py`).

The docs are hosted at: https://takumi-sols.github.io/starlette-sourcey-docs/

## Notes

- This does not replace or modify any existing docs — it adds a pointer to an alternative reference
- The Sourcey build is reproducible from the pinned commit
- The generated docs are 709KB (single-page HTML, no external dependencies)
- If maintainers prefer to host the docs on `starlette.dev` directly, the generated `index.html` can be added to the `docs/` directory and built with MkDocs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/starlette/pull/3424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

